### PR TITLE
Emacs: Use replace-buffer-contents for replacing the original with the formatted code

### DIFF
--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -213,22 +213,19 @@ the file."
                                   (goto-char (point-max))
                                   (when (looking-back "\n" (1- (point)))
                                     (delete-char -1)))
+				(delete-trailing-whitespace)
                                 (buffer-string))))
                 (if (not (string= new-str orig-str))
-                    (let ((line (line-number-at-pos))
-                          (col (current-column)))
-                      (delete-region beg
-                                     end)
-                      (let ((new-start (point)))
-                        (insert new-str)
-                        (let ((new-end (point)))
-                          (goto-char (point-min))
-                          (forward-line (1- line))
-                          (goto-char (+ (line-beginning-position) col))
-                          (when (looking-back "^[ ]+" (line-beginning-position))
-                            (back-to-indentation))
-                          (delete-trailing-whitespace new-start new-end)))
-                      (message "Formatted."))
+		    (progn
+		      (if (fboundp 'replace-region-contents)
+			  (replace-region-contents
+			   beg end (lambda () temp))
+			(let ((line (line-number-at-pos))
+			      (col (current-column)))
+			  (delete-region beg
+					 end)
+			  (insert new-str)))
+		      (message "Formatted."))
                   (message "Already formatted.")))))))))))
 
 (defun hindent-decl-points ()


### PR DESCRIPTION
See the commit message for details.

Sorry for not creating a separate branch for this contribution from which you
can pull, but that's the only thing I've been missing from hindent anyway, so I
won't clobber my master branch with unrelated changes anyway. :-)

Keep up the good work!