### PR TITLE
Add documentation for 'line-breaks' and 'extensions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ indent-size: 2
 line-length: 80
 force-trailing-newline: true
 line-breaks: [":>", ":<|>"]
+extensions:
+  - DataKinds
+  - GADTs
+  - TypeApplications
 ```
 
 By default, HIndent preserves the newline or lack of newline in your input. With `force-trailing-newline`, it will make sure there is always a trailing newline.
 
 hindent can be forced to insert a newline before specific operators and tokens with `line-breaks`. This is especially useful when utilizing libraries like [`servant`](https://www.servant.dev/) which use long type aliases.
+
+Using `extensions`, hindent can be made aware of valid syntactic compiler extensions that would normally be considered invalid syntax.
 
 ## Emacs
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ default:
 indent-size: 2
 line-length: 80
 force-trailing-newline: true
+line-breaks: [":>", ":<|>"]
 ```
 
 By default, HIndent preserves the newline or lack of newline in your input. With `force-trailing-newline`, it will make sure there is always a trailing newline.
+
+hindent can be forced to insert a newline before specific operators and tokens with `line-breaks`. This is especially useful when utilizing libraries like [`servant`](https://www.servant.dev/) which use long type aliases.
 
 ## Emacs
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ extensions:
   - TypeApplications
 ```
 
-By default, HIndent preserves the newline or lack of newline in your input. With `force-trailing-newline`, it will make sure there is always a trailing newline.
+By default, hindent preserves the newline or lack of newline in your input. With `force-trailing-newline`, it will make sure there is always a trailing newline.
 
 hindent can be forced to insert a newline before specific operators and tokens with `line-breaks`. This is especially useful when utilizing libraries like [`servant`](https://www.servant.dev/) which use long type aliases.
 


### PR DESCRIPTION
[Sort of in response to my own words.](https://github.com/chrisdone/hindent/issues/466#issuecomment-512796222)

The more documentation in the README about configuration options for Hindent, the fewer duplicate issues there will be about missing features that are already implemented. Currently, having to dig through issues and commits to figure out how `line-breaks` and `extensions` work is more hassle than it needs to be. Adding some documentation about these configuration options helps alleviate that.