### PR TITLE
Support GHC 8.8.1

### DIFF
--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -71,7 +71,7 @@ data Config = Config
     }
 
 -- | Parse an extension.
-readExtension :: Monad m => String -> m Extension
+readExtension :: MonadFail m => String -> m Extension
 readExtension x =
   case classifyExtension x -- Foo
        of


### PR DESCRIPTION
Fix the error with fail requiring MonadFail.

```
src/HIndent/Types.hs:78:27: error:
    • Could not deduce (MonadFail m) arising from a use of ‘fail’
      from the context: Monad m
        bound by the type signature for:
                   readExtension :: forall (m :: * -> *).
                                    Monad m =>
                                    String -> m Extension
        at src/HIndent/Types.hs:74:1-49
```