### PR TITLE
Feature/haskell src exts 1.22.0

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -431,12 +431,39 @@ type family Closed (a :: k) :: Bool where
   Closed x = 'True
 ```
 
+Unboxed sum types
+
+```haskell
+{-# LANGUAGE UnboxedSums #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+f :: (# (# Int, String #) | String #) -> (# Int | String #)
+f (# (# n, _ #) | #) = (# n | #)
+f (# | b #) = (# | b #)
+
+f' ::
+     (#  (# Int, String #)
+       | Either Bool Int
+       | Either Bool Int
+       | Either Bool Int
+       | Either Bool Int
+       | Either Bool Int
+       | String #)
+  -> (# Int | String #)
+```
+
 # Template Haskell
 
 Expression brackets
 
 ```haskell
 add1 x = [|x + 1|]
+```
+
+Typed expression brackets
+
+```haskell
+add1 x = [||x + 1||]
 ```
 
 Pattern brackets
@@ -449,6 +476,12 @@ Type brackets
 
 ```haskell
 foo :: $([t|Bool|]) -> a
+```
+
+Typed variable splice
+
+```haskell
+add2Typed = [||$$myFuncTyped . $$(myFuncTyped)||]
 ```
 
 Quoted data constructors
@@ -1416,6 +1449,38 @@ newtype Number a =
   deriving (Generic)
   deriving newtype (Show, Eq)
   deriving anyclass (Typeable)
+```
+
+Deriving via
+```haskell
+{-# LANGUAGE DerivingVia #-}
+
+import Numeric
+
+newtype Hex a =
+  Hex a
+
+instance (Integral a, Show a) => Show (Hex a) where
+  show (Hex a) = "0x" ++ showHex a ""
+
+newtype Unicode =
+  U Int
+  deriving (Show) via (Hex Int)
+  deriving ( Functor
+           , Applicative
+           , Monad
+           , Semigroup
+           , Monoid
+           , Alternative
+           , MonadPlus
+           , Foldable
+           , Traversable
+           ) via (Hex Int)
+
+-- >>> euroSign
+-- 0x20ac
+euroSign :: Unicode
+euroSign = U 0x20ac
 ```
 
 neongreen "{" is lost when formatting "Foo{}" #366

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1022,6 +1022,7 @@ instance Pretty Asst where
             write "_"
             pretty n
 #endif
+#endif
 
 instance Pretty BangType where
   prettyInternal x =

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE CPP #-}
 
 -- | All types.
 
@@ -70,8 +71,12 @@ data Config = Config
       -- ^ Extra language extensions enabled by default.
     }
 
+#if __GLASGOW_HASKELL__ >= 808
 -- | Parse an extension.
+readExtension :: MonadFail m => String -> m Extension
+#else
 readExtension :: Monad m => String -> m Extension
+#endif
 readExtension x =
   case classifyExtension x -- Foo
        of

--- a/src/main/Test.hs
+++ b/src/main/Test.hs
@@ -61,7 +61,7 @@ toSpec = go
                 shouldBeReadable (reformat cfg code) (L.fromStrict codeExpect)
               go next'
             _ ->
-              fail
+              error
                 "'haskell given' block must be followed by a 'haskell expect' block"
         "haskell pending" -> do
           it (UTF8.toString desc) pending

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,6 @@
-resolver: lts-11.8
+resolver: lts-15.5
 packages:
 - '.'
 extra-deps:
-- haskell-src-exts-1.20.2
-- path-0.5.9
-- path-io-1.2.0
 
 allow-newer: True


### PR DESCRIPTION
- Add Pretty implementation of:
  - UnboxedSum patterns, expressions, and types (since
    haskell-src-exts 1.20.0).
  - DerivingVia (since haskell-src-exts 1.21.0).
  - Typed Template Haskell splices and expressions (since
    haskell-src-exts 1.22.0).
- Update "Pretty Asst" instance to match new "Asst" structure in
  haskell-src-exts 1.22.0.
- Move stackage snapshot to "lts-15.5" and use "MonadFail".
- Use "error" in "src/main/Test.hs" instead of "fail" as "SpecM" does
  not have an instance of MonadFail (yet).
- Remove unused functions "isRecord", "recDecl", and "qualConDecl".