### PR TITLE
Support GHC >= 8.8 with MonadFail

### DIFF
--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -cpp #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}

--- a/src/HIndent/Types.hs
+++ b/src/HIndent/Types.hs
@@ -71,7 +71,11 @@ data Config = Config
     }
 
 -- | Parse an extension.
+#if __GLASGOW_HASKELL__ >= 808
+readExtension :: (Monad m, MonadFail m) => String -> m Extension
+#else
 readExtension :: Monad m => String -> m Extension
+#endif
 readExtension x =
   case classifyExtension x -- Foo
        of


### PR DESCRIPTION
Uses conditional statement for the C pre-processor for backward compatibility.