### PR TITLE
Add Dockerfile with hindent for easy use via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+ARG debian_version='stretch-slim'
+ARG ghc_version='8.2.2'
+
+
+FROM haskell:"${ghc_version}" as build
+ARG hindent_version='5.3.1'
+ARG stack_resolver_version='lts-11.22'
+RUN stack --resolver "${stack_resolver_version}" install \
+    --ghc-options='-fPIC -optl-static' "hindent-${hindent_version}"
+
+
+FROM debian:"${debian_version}"
+
+LABEL org.opencontainers.image.title='hindent'
+LABEL org.opencontainers.image.url='https://github.com/mihaimaruseac/hindent'
+
+ARG libgmp_dev_version='2:6.1.2+dfsg-1'
+
+RUN apt-get update \
+  && apt-get install --assume-yes --no-install-recommends \
+    "libgmp-dev=${libgmp_dev_version}" \
+  && apt-get clean \
+  && rm --force --recursive /var/lib/apt/lists/*
+
+COPY --from=build /root/.local/bin/hindent /usr/local/bin/hindent
+
+ENTRYPOINT ["hindent"]

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,1 @@
+The scripts in this folder are [Docker Hub hooks](https://docs.docker.com/docker-hub/builds/advanced/) that automatically build and push images.

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+docker build \
+  --build-arg "hindent_version=${DOCKER_TAG}" \
+  --file "${DOCKERFILE_PATH}" \
+  --tag "${IMAGE_NAME}" \
+  .

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly latest_image="${DOCKER_REPO}:latest"
+docker tag "${IMAGE_NAME}" "${latest_image}"
+docker push "${latest_image}"

--- a/scripts/test-docker
+++ b/scripts/test-docker
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+lint_dockerfile() {
+  local -r dockerfile_path="$1"
+  docker run --interactive --rm hadolint/hadolint:v1.18.2 < "${dockerfile_path}"
+}
+
+build_image() {
+  DOCKER_TAG="$1" DOCKERFILE_PATH="$2" IMAGE_NAME="$3" hooks/build
+}
+
+test_image() {
+  local -r hindent_version="$1"
+  local -r image_name="$2"
+
+  diff <(docker run --rm "${image_name}" --version) \
+    <(echo "hindent ${hindent_version}")
+
+  diff <(echo 'example = case x of Just p -> foo bar' \
+    | docker run --interactive --rm "${image_name}" --indent-size 2) \
+    <(printf "example =\n  case x of\n    Just p -> foo bar\n")
+}
+
+main() {
+  local -r script_folder="$(dirname "$(readlink --canonicalize "$0")")"
+  local -r project_folder="$(dirname "${script_folder}")"
+  pushd "${project_folder}"
+
+  local -r hindent_version=5.3.1
+  local -r dockerfile_path=Dockerfile
+  local -r image_name=hindent:dirty
+
+  lint_dockerfile "${dockerfile_path}"
+  build_image "${hindent_version}" "${dockerfile_path}" "${image_name}"
+  test_image "${hindent_version}" "${image_name}"
+}
+
+main "$@"


### PR DESCRIPTION
There are Docker Hub hooks in the `hooks` folder to automatically build and push a Docker image with the given hindent version (for example, with a Docker Hub rule that triggers on Git tags).

The Dockerfile can be tested with

```
scripts/test-docker
```

The Bash scripts have been linted with [ShellCheck](https://github.com/koalaman/shellcheck) as in

```
docker run --interactive --rm --volume "$(pwd):/mnt" \
  koalaman/shellcheck:v0.7.1 \
  hooks/build hooks/post_push scripts/test-docker
```

This addresses mihaimaruseac/hindent#571.

A Docker Hub autobuild rule would need to be configured separately. Example of a rule that would trigger on a Git tag push:

![docker_hub_build_configuration](https://user-images.githubusercontent.com/8361681/98470823-899f9b80-21e8-11eb-8080-cfda470e144c.png)

This build rule assumes that the package is uploaded to Hackage _before_ the corresponding tag is pushed to GitHub, so that the triggered `stack install …` in the `Dockerfile` can access the just uploaded package version.

I can help configuring a Docker Hub repository `mihaimaruseac/hindent`, but it should probably be owned by the same people as the code base.