### PR TITLE
Remove all `\r`s when reading `TESTS.md`

### DIFF
--- a/src/main/Markdone.hs
+++ b/src/main/Markdone.hs
@@ -72,7 +72,7 @@ tokenize input = evalState (mapM token (S8.lines input)) Normal
                             line)
                    else return $ PlainLine line
         Fenced ->
-          if line == "```"
+          if line == "```" || line=="```\r"
             then do
               put Normal
               return EndFence

--- a/src/main/Markdone.hs
+++ b/src/main/Markdone.hs
@@ -72,7 +72,7 @@ tokenize input = evalState (mapM token (S8.lines input)) Normal
                             line)
                    else return $ PlainLine line
         Fenced ->
-          if line == "```" || line=="```\r"
+          if line == "```" || line == "```\r"
             then do
               put Normal
               return EndFence

--- a/src/main/Markdone.hs
+++ b/src/main/Markdone.hs
@@ -50,7 +50,7 @@ data TokenizerMode
 
 -- | Tokenize the bytestring.
 tokenize :: ByteString -> [Token]
-tokenize input = evalState (mapM token (S8.lines input)) Normal
+tokenize input = evalState (mapM token (S8.filter (/= '\r') <$> S8.lines input)) Normal
   where
     token :: ByteString -> State TokenizerMode Token
     token line = do
@@ -72,7 +72,7 @@ tokenize input = evalState (mapM token (S8.lines input)) Normal
                             line)
                    else return $ PlainLine line
         Fenced ->
-          if line == "```" || line == "```\r"
+          if line == "```"
             then do
               put Normal
               return EndFence


### PR DESCRIPTION
[`bytestring`'s `lines` does not handle `\r`](https://hackage.haskell.org/package/bytestring-0.11.3.1/docs/Data-ByteString-Char8.html#v:lines
), and that made the test
program not detecting enclosing "\`\`\`"s. This PR removes all `\r`s to prevent the tests from causing the `NoFenceEnd` error on Windows.