### PR TITLE
Fix mojibake on test on Windows

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1710,7 +1710,7 @@ class (Eq a, Show a) =>
   fromInteger :: Integer -> a
 ```
 
-michalrus `let … in …` inside of `do` breaks compilation #467
+michalrus `let ... in ...` inside of `do` breaks compilation #467
 
 ```haskell
 -- https://github.com/commercialhaskell/hindent/issues/467


### PR DESCRIPTION
`…` is printed as `�c` on Windows.
