### PR TITLE
Explicitly import `Paths_hindent`

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -55,7 +55,8 @@ executable hindent
   ghc-options:       -Wall -O2
   default-language:  Haskell2010
   main-is:           Main.hs
-  other-modules: Path.Find
+  other-modules:     Path.Find
+                     Paths_hindent
   build-depends:     base >= 4 && < 5
                    , hindent
                    , bytestring


### PR DESCRIPTION
To suppress a warning. The code compiles without the import, but I think it's better to explicitly import it.
