### PR TITLE
Change the supported GHC versions.

### DIFF
--- a/.github/workflows/Cabal.yml
+++ b/.github/workflows/Cabal.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false  # Windows builds randomly fail
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc: ["8.2.2", "8.4.4", "8.6.5", "8.8.4", "8.10.2", "9.2.2"]
+        ghc: ["8.10.7", "9.2.2", "9.4.1"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:


### PR DESCRIPTION
We will now support GHC 8.10.7, GHC 9.2.2 and GHC 9.4.1 in CI. This is because `ghc-lib-parser` changes the AST parsing near GHC 8.10.