### PR TITLE
Remove the support for GHC 9.4.1 on Windows

### DIFF
--- a/.github/workflows/Cabal.yml
+++ b/.github/workflows/Cabal.yml
@@ -18,7 +18,10 @@ jobs:
       fail-fast: false  # Windows builds randomly fail
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc: ["8.10.7", "9.2.2"]
+        ghc: ["8.10.7", "9.2.2", "9.4.1"]
+        exclude:
+        - os: windows-latest
+          ghc: "9.4.1"
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:

--- a/.github/workflows/Cabal.yml
+++ b/.github/workflows/Cabal.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false  # Windows builds randomly fail
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc: ["8.10.7", "9.2.2", "9.4.1"]
+        ghc: ["8.10.7", "9.2.2"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:


### PR DESCRIPTION
Building the project with the GHC version fails. This problem is [already reported in the upstream](https://gitlab.haskell.org/ghc/ghc/-/issues/21990).