### PR TITLE
Create more sections in the test suite file

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -172,24 +172,25 @@ instance (:?:) Int Bool
 
 ### Data declarations
 
-GADT declarations
+Non-bang fields
 
 ```haskell
-data Ty :: (* -> *) where
-  TCon
-    :: { field1 :: Int
-       , field2 :: Bool}
-    -> Ty Bool
-  TCon' :: (a :: *) -> a -> Ty a
+data HttpException
+  = InvalidStatusCode Int
+  | MissingContentHeader
 ```
 
-Data declarations
+Bang fields
 
 ```haskell
 data Tree a
   = Branch !a !(Tree a) !(Tree a)
   | Leaf
+```
 
+A constructor with many parameters
+
+```haskell
 data Tree a
   = Branch
       !a
@@ -201,18 +202,11 @@ data Tree a
       !(Tree a)
       !(Tree a)
   | Leaf
+```
 
-data HttpException
-  = InvalidStatusCode Int
-  | MissingContentHeader
+Multiple data constructors with fields
 
-data Person =
-  Person
-    { firstName :: !String -- ^ First name
-    , lastName :: !String -- ^ Last name
-    , age :: !Int -- ^ Age
-    }
-
+```haskell
 data Expression a
   = VariableExpression
       { id :: Id Expression
@@ -232,6 +226,17 @@ data Expression a
       { id :: Id Constructor
       , label :: a
       }
+```
+
+GADT declarations
+
+```haskell
+data Ty :: (* -> *) where
+  TCon
+    :: { field1 :: Int
+       , field2 :: Bool}
+    -> Ty Bool
+  TCon' :: (a :: *) -> a -> Ty a
 ```
 
 Spaces between deriving classes
@@ -1060,6 +1065,17 @@ Etc.
 -}
 main = putStrLn "Hello, World!"
 {- This is another random comment. -}
+```
+
+Comments after fields of a data declaration
+
+```haskell
+data Person =
+  Person
+    { firstName :: !String -- ^ First name
+    , lastName :: !String -- ^ Last name
+    , age :: !Int -- ^ Age
+    }
 ```
 
 ## MINIMAL pragma

--- a/TESTS.md
+++ b/TESTS.md
@@ -409,43 +409,6 @@ f = \ !a -> undefined
 -- \!a yields parse error on input ‘\!’
 ```
 
-## Template Haskell
-
-Expression brackets
-
-```haskell
-add1 x = [|x + 1|]
-```
-
-Pattern brackets
-
-```haskell
-mkPat = [p|(x, y)|]
-```
-
-Type brackets
-
-```haskell
-foo :: $([t|Bool|]) -> a
-```
-
-Quoted data constructors
-
-```haskell
-cons = '(:)
-```
-
-Pattern splices
-
-```haskell
-f $pat = ()
-
-g =
-  case x of
-    $(mkPat y z) -> True
-    _ -> False
-```
-
 ### Records
 
 Short
@@ -489,6 +452,43 @@ With symbol field
 f x = x {(..?) = wat}
 
 g x = Rec {(..?)}
+```
+
+## Template Haskell
+
+Expression brackets
+
+```haskell
+add1 x = [|x + 1|]
+```
+
+Pattern brackets
+
+```haskell
+mkPat = [p|(x, y)|]
+```
+
+Type brackets
+
+```haskell
+foo :: $([t|Bool|]) -> a
+```
+
+Quoted data constructors
+
+```haskell
+cons = '(:)
+```
+
+Pattern splices
+
+```haskell
+f $pat = ()
+
+g =
+  case x of
+    $(mkPat y z) -> True
+    _ -> False
 ```
 
 ### Function signatures

--- a/TESTS.md
+++ b/TESTS.md
@@ -220,22 +220,6 @@ Type application
 fun @Int 12
 ```
 
-Transform list comprehensions
-
-```haskell
-list =
-  [ (x, y, map the v)
-  | x <- [1 .. 10]
-  , y <- [1 .. 10]
-  , let v = x + y
-  , then group by v using groupWith
-  , then take 10
-  , then group using permutations
-  , t <- concat v
-  , then takeWhile by t < 3
-  ]
-```
-
 Type families
 
 ```haskell
@@ -303,6 +287,22 @@ With operators
 defaultExtensions =
   [e | e@EnableExtension {} <- knownExtensions] \\
   map EnableExtension badExtensions
+```
+
+Transform list comprehensions
+
+```haskell
+list =
+  [ (x, y, map the v)
+  | x <- [1 .. 10]
+  , y <- [1 .. 10]
+  , let v = x + y
+  , then group by v using groupWith
+  , then take 10
+  , then group using permutations
+  , t <- concat v
+  , then takeWhile by t < 3
+  ]
 ```
 
 #### Parallel list comprehensions

--- a/TESTS.md
+++ b/TESTS.md
@@ -193,20 +193,6 @@ type MyContext m
 
 ## Expressions
 
-Lazy patterns in a lambda
-
-``` haskell
-f = \ ~a -> undefined
--- \~a yields parse error on input ‘\~’
-```
-
-Bang patterns in a lambda
-
-``` haskell
-f = \ !a -> undefined
--- \!a yields parse error on input ‘\!’
-```
-
 List comprehensions, short
 
 ``` haskell
@@ -444,6 +430,22 @@ Closed type families
 ```haskell
 type family Closed (a :: k) :: Bool where
   Closed x = 'True
+```
+
+### Lambda expressions
+
+Lazy patterns
+
+``` haskell
+f = \ ~a -> undefined
+-- \~a yields parse error on input ‘\~’
+```
+
+Bang patterns
+
+``` haskell
+f = \ !a -> undefined
+-- \!a yields parse error on input ‘\!’
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -157,6 +157,19 @@ instance Bool :?: Bool
 instance (:?:) Int Bool
 ```
 
+### Data declarations
+
+GADT declarations
+
+```haskell
+data Ty :: (* -> *) where
+  TCon
+    :: { field1 :: Int
+       , field2 :: Bool}
+    -> Ty Bool
+  TCon' :: (a :: *) -> a -> Ty a
+```
+
 ### Type synonyms
 
 Short
@@ -176,17 +189,6 @@ type MyContext m
      , MonadMask m
      , Monoid m
      , Functor m)
-```
-
-GADT declarations
-
-```haskell
-data Ty :: (* -> *) where
-  TCon
-    :: { field1 :: Int
-       , field2 :: Bool}
-    -> Ty Bool
-  TCon' :: (a :: *) -> a -> Ty a
 ```
 
 ## Expressions

--- a/TESTS.md
+++ b/TESTS.md
@@ -600,6 +600,59 @@ f =
    in f
 ```
 
+### Pattern matchings against records
+
+Short
+
+```haskell
+fun Rec {alpha = beta, gamma = delta, epsilon = zeta, eta = theta, iota = kappa} = do
+  beta + delta + zeta + theta + kappa
+```
+
+Long
+
+```haskell
+fun Rec { alpha = beta
+        , gamma = delta
+        , epsilon = zeta
+        , eta = theta
+        , iota = kappa
+        , lambda = mu
+        } =
+  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
+```
+
+Symbol constructor, short
+
+```haskell
+fun ((:..?) {}) = undefined
+```
+
+Symbol constructor, long
+
+```haskell
+fun (:..?) { alpha = beta
+           , gamma = delta
+           , epsilon = zeta
+           , eta = theta
+           , iota = kappa
+           , lambda = mu
+           } =
+  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
+```
+
+Symbol field
+
+```haskell
+f (X {(..?) = x}) = x
+```
+
+Punned symbol field
+
+```haskell
+f' (X {(..?)}) = (..?)
+```
+
 ## Template Haskell
 
 Expression brackets
@@ -740,59 +793,6 @@ test
   ,
   , nu81
   ,)
-```
-
-## Record syntax
-
-Pattern matching, short
-
-```haskell
-fun Rec {alpha = beta, gamma = delta, epsilon = zeta, eta = theta, iota = kappa} = do
-  beta + delta + zeta + theta + kappa
-```
-
-Pattern matching, long
-
-```haskell
-fun Rec { alpha = beta
-        , gamma = delta
-        , epsilon = zeta
-        , eta = theta
-        , iota = kappa
-        , lambda = mu
-        } =
-  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
-```
-
-Symbol constructor, short
-
-```haskell
-fun ((:..?) {}) = undefined
-```
-
-Symbol constructor, long
-
-```haskell
-fun (:..?) { alpha = beta
-           , gamma = delta
-           , epsilon = zeta
-           , eta = theta
-           , iota = kappa
-           , lambda = mu
-           } =
-  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
-```
-
-Symbol field
-
-```haskell
-f (X {(..?) = x}) = x
-```
-
-Punned symbol field
-
-```haskell
-f' (X {(..?)}) = (..?)
 ```
 
 ## Johan Tibell compatibility checks

--- a/TESTS.md
+++ b/TESTS.md
@@ -149,6 +149,14 @@ instance C a where
     k p
 ```
 
+Symbol class constructor
+
+```haskell
+instance Bool :?: Bool
+
+instance (:?:) Int Bool
+```
+
 ### Type synonyms
 
 Short
@@ -168,14 +176,6 @@ type MyContext m
      , MonadMask m
      , Monoid m
      , Functor m)
-```
-
-Symbol class constructor in instance declaration
-
-```haskell
-instance Bool :?: Bool
-
-instance (:?:) Int Bool
 ```
 
 GADT declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -212,20 +212,6 @@ cons = (:)
 cons' = (:|)
 ```
 
-Binary symbol data constructor in pattern
-
-```haskell
-f (x :| _) = x
-
-f' ((:|) x _) = x
-
-f'' ((Data.List.NonEmpty.:|) x _) = x
-
-g (x:xs) = x
-
-g' ((:) x _) = x
-```
-
 Type application
 
 ```haskell
@@ -456,6 +442,20 @@ n+k patterns
 
 ``` haskell
 f (n+5) = 0
+```
+
+Binary symbol data constructor in pattern
+
+```haskell
+f (x :| _) = x
+
+f' ((:|) x _) = x
+
+f'' ((Data.List.NonEmpty.:|) x _) = x
+
+g (x:xs) = x
+
+g' ((:) x _) = x
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -7,12 +7,7 @@ sure re-formatting that code snippet produces the same result.
 You can browse through this document to see what HIndent's style is
 like, or contribute additional sections to it, or regression tests.
 
-## Modules
-
-Empty module
-
-``` haskell
-```
+## Shebang
 
 Double shebangs
 
@@ -22,15 +17,16 @@ Double shebangs
 main = pure ()
 ```
 
-Extension pragmas
+## Module
 
-```haskell
-{-# LANGUAGE TypeApplications #-}
+Empty module
 
-fun @Int 12
+``` haskell
 ```
 
-Module header
+### Module header
+
+Without an export list
 
 ``` haskell
 module X where
@@ -38,7 +34,7 @@ module X where
 x = 1
 ```
 
-Exports
+With an export list
 
 ``` haskell
 module X
@@ -49,7 +45,7 @@ module X
   ) where
 ```
 
-Exports, indentation 4
+With an export list and indentation 4
 
 ``` haskell 4
 module X
@@ -58,6 +54,16 @@ module X
     , Z
     , P(x, z)
     ) where
+```
+
+### Module-level pragma
+
+Extension pragmas
+
+```haskell
+{-# LANGUAGE TypeApplications #-}
+
+fun @Int 12
 ```
 
 ## Imports

--- a/TESTS.md
+++ b/TESTS.md
@@ -132,10 +132,25 @@ import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 
 ## Declarations
 
-Type declaration
+### Type synonyms
 
-``` haskell
+Short
+
+```haskell
 type EventSource a = (AddHandler a, a -> IO ())
+```
+
+Long
+
+```haskell
+-- https://github.com/commercialhaskell/hindent/issues/290
+type MyContext m
+   = ( MonadState Int m
+     , MonadReader Int m
+     , MonadError Text m
+     , MonadMask m
+     , Monoid m
+     , Functor m)
 ```
 
 Type declaration with infix promoted type constructor
@@ -1526,19 +1541,6 @@ someFunctionSignature ::
   -> Enough
   -> (Arguments -> To ())
   -> Overflow (The Line Limit)
-```
-
-duog Long Type Constraint Synonyms are not reformatted #290
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/290
-type MyContext m
-   = ( MonadState Int m
-     , MonadReader Int m
-     , MonadError Text m
-     , MonadMask m
-     , Monoid m
-     , Functor m)
 ```
 
 ocharles Type application differs from function application (leading to long lines) #359

--- a/TESTS.md
+++ b/TESTS.md
@@ -204,53 +204,6 @@ strToMonth month =
     _ -> error $ "Unknown month " ++ month
 ```
 
-Operators, bad
-
-``` haskell
-x =
-  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
-  Just thisissolong <*>
-  Just stilllonger <*>
-  evenlonger
-```
-
-Operators, good
-
-```haskell pending
-x =
-  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
-  Just thisissolong <*> Just stilllonger <*> evenlonger
-```
-
-Operator with `do`
-
-```haskell
-for xs $ do
-  left x
-  right x
-```
-
-Operator with lambda
-
-```haskell
-for xs $ \x -> do
-  left x
-  right x
-```
-
-Operator with lambda-case
-
-```haskell
-for xs $ \case
-  Left x -> x
-```
-
-Operator in parentheses
-
-```haskell
-cat = (++)
-```
-
 Symbol data constructor in parentheses
 
 ```haskell
@@ -452,6 +405,55 @@ With symbol field
 f x = x {(..?) = wat}
 
 g x = Rec {(..?)}
+```
+
+### Operators
+
+Bad
+
+``` haskell
+x =
+  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
+  Just thisissolong <*>
+  Just stilllonger <*>
+  evenlonger
+```
+
+Good
+
+```haskell pending
+x =
+  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
+  Just thisissolong <*> Just stilllonger <*> evenlonger
+```
+
+With `do`
+
+```haskell
+for xs $ do
+  left x
+  right x
+```
+
+With lambda
+
+```haskell
+for xs $ \x -> do
+  left x
+  right x
+```
+
+With lambda-case
+
+```haskell
+for xs $ \case
+  Left x -> x
+```
+
+Operator in parentheses
+
+```haskell
+cat = (++)
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -212,12 +212,6 @@ cons = (:)
 cons' = (:|)
 ```
 
-n+k patterns
-
-``` haskell
-f (n+5) = 0
-```
-
 Binary symbol data constructor in pattern
 
 ```haskell
@@ -454,6 +448,14 @@ Operator in parentheses
 
 ```haskell
 cat = (++)
+```
+
+## Pattern matchings
+
+n+k patterns
+
+``` haskell
+f (n+5) = 0
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -190,6 +190,13 @@ With dependencies
 type family Id a = r | r -> a
 ```
 
+Closed type families
+
+```haskell
+type family Closed (a :: k) :: Bool where
+  Closed x = 'True
+```
+
 ### Type synonyms
 
 Short
@@ -252,13 +259,6 @@ Binding implicit parameters
 f =
   let ?x = 42
    in f
-```
-
-Closed type families
-
-```haskell
-type family Closed (a :: k) :: Bool where
-  Closed x = 'True
 ```
 
 ### List comprehensions

--- a/TESTS.md
+++ b/TESTS.md
@@ -132,6 +132,23 @@ import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 
 ## Declarations
 
+### Class instance declarations
+
+Without declarations
+
+``` haskell
+instance C a
+```
+
+With declarations
+
+``` haskell
+instance C a where
+  foobar = do
+    x y
+    k p
+```
+
 ### Type synonyms
 
 Short
@@ -151,31 +168,6 @@ type MyContext m
      , MonadMask m
      , Monoid m
      , Functor m)
-```
-
-Type declaration with infix promoted type constructor
-
-```haskell
-fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
-fun1 = undefined
-
-fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
-fun2 = undefined
-```
-
-Instance declaration without decls
-
-``` haskell
-instance C a
-```
-
-Instance declaration with decls
-
-``` haskell
-instance C a where
-  foobar = do
-    x y
-    k p
 ```
 
 Symbol class constructor in instance declaration
@@ -489,7 +481,17 @@ g =
     _ -> False
 ```
 
-## Type signatures
+### Function signatures
+
+Type declaration with infix promoted type constructor
+
+```haskell
+fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+fun1 = undefined
+
+fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
+fun2 = undefined
+```
 
 Long argument list should line break
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -193,25 +193,6 @@ type MyContext m
 
 ## Expressions
 
-Parallel list comprehension, short
-
-```haskell
-zip xs ys = [(x, y) | x <- xs | y <- ys]
-```
-
-Parallel list comprehension, long
-
-```haskell
-fun xs ys =
-  [ (alphaBetaGamma, deltaEpsilonZeta)
-  | x <- xs
-  , z <- zs
-  | y <- ys
-  , cond
-  , let t = t
-  ]
-```
-
 Record, short
 
 ``` haskell
@@ -432,6 +413,27 @@ With operators
 defaultExtensions =
   [e | e@EnableExtension {} <- knownExtensions] \\
   map EnableExtension badExtensions
+```
+
+#### Parallel list comprehensions
+
+Short
+
+```haskell
+zip xs ys = [(x, y) | x <- xs | y <- ys]
+```
+
+Long
+
+```haskell
+fun xs ys =
+  [ (alphaBetaGamma, deltaEpsilonZeta)
+  | x <- xs
+  , z <- zs
+  | y <- ys
+  , cond
+  , let t = t
+  ]
 ```
 
 ### Lambda expressions

--- a/TESTS.md
+++ b/TESTS.md
@@ -193,49 +193,6 @@ type MyContext m
 
 ## Expressions
 
-Record, short
-
-``` haskell
-getGitProvider :: EventProvider GitRecord ()
-getGitProvider =
-  EventProvider {getModuleName = "Git", getEvents = getRepoCommits}
-```
-
-Record, medium
-
-``` haskell
-commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
-commitToEvent gitFolderPath timezone commit =
-  Event.Event
-    {pluginName = getModuleName getGitProvider, eventIcon = "glyphicon-cog"}
-```
-
-Record, long
-
-``` haskell
-commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
-commitToEvent gitFolderPath timezone commit =
-  Event.Event
-    { pluginName = getModuleName getGitProvider
-    , eventIcon = "glyphicon-cog"
-    , eventDate = localTimeToUTC timezone (commitDate commit)
-    }
-```
-
-Record with symbol constructor
-
-```haskell
-f = (:..?) {}
-```
-
-Record with symbol field
-
-```haskell
-f x = x {(..?) = wat}
-
-g x = Rec {(..?)}
-```
-
 Cases
 
 ``` haskell
@@ -487,6 +444,51 @@ g =
   case x of
     $(mkPat y z) -> True
     _ -> False
+```
+
+### Records
+
+Short
+
+``` haskell
+getGitProvider :: EventProvider GitRecord ()
+getGitProvider =
+  EventProvider {getModuleName = "Git", getEvents = getRepoCommits}
+```
+
+Medium
+
+``` haskell
+commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
+commitToEvent gitFolderPath timezone commit =
+  Event.Event
+    {pluginName = getModuleName getGitProvider, eventIcon = "glyphicon-cog"}
+```
+
+Long
+
+``` haskell
+commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
+commitToEvent gitFolderPath timezone commit =
+  Event.Event
+    { pluginName = getModuleName getGitProvider
+    , eventIcon = "glyphicon-cog"
+    , eventDate = localTimeToUTC timezone (commitDate commit)
+    }
+```
+
+With symbol constructor
+
+```haskell
+f = (:..?) {}
+```
+
+With symbol field
+
+```haskell
+f x = x {(..?) = wat}
+
+g x = Rec {(..?)}
 ```
 
 ### Function signatures

--- a/TESTS.md
+++ b/TESTS.md
@@ -438,14 +438,14 @@ defaultExtensions =
 
 Lazy patterns
 
-``` haskell
+```haskell
 f = \ ~a -> undefined
 -- \~a yields parse error on input ‘\~’
 ```
 
 Bang patterns
 
-``` haskell
+```haskell
 f = \ !a -> undefined
 -- \!a yields parse error on input ‘\!’
 ```

--- a/TESTS.md
+++ b/TESTS.md
@@ -378,6 +378,21 @@ x =
      | otherwise -> e
 ```
 
+Lists
+
+``` haskell
+exceptions = [InvalidStatusCode, MissingContentHeader, InternalServerError]
+
+exceptions =
+  [ InvalidStatusCode
+  , MissingContentHeader
+  , InternalServerError
+  , InvalidStatusCode
+  , MissingContentHeader
+  , InternalServerError
+  ]
+```
+
 ### List comprehensions
 
 Short
@@ -680,21 +695,6 @@ g x =
       let y = 2
           z = 3
        in y
-```
-
-Lists
-
-``` haskell
-exceptions = [InvalidStatusCode, MissingContentHeader, InternalServerError]
-
-exceptions =
-  [ InvalidStatusCode
-  , MissingContentHeader
-  , InternalServerError
-  , InvalidStatusCode
-  , MissingContentHeader
-  , InternalServerError
-  ]
 ```
 
 Long line, function application

--- a/TESTS.md
+++ b/TESTS.md
@@ -185,7 +185,7 @@ data Ty :: (* -> *) where
 
 Data declarations
 
-``` haskell
+```haskell
 data Tree a
   = Branch !a !(Tree a) !(Tree a)
   | Leaf

--- a/TESTS.md
+++ b/TESTS.md
@@ -170,6 +170,26 @@ data Ty :: (* -> *) where
   TCon' :: (a :: *) -> a -> Ty a
 ```
 
+### Type families
+
+Without an annotation
+
+```haskell
+type family Id a
+```
+
+With an annotation
+
+```haskell
+type family Id a :: *
+```
+
+With dependencies
+
+```haskell
+type family Id a = r | r -> a
+```
+
 ### Type synonyms
 
 Short
@@ -220,28 +240,10 @@ Type application
 fun @Int 12
 ```
 
-Type families
-
-```haskell
-type family Id a
-```
-
-Type family annotations
-
-``` haskell
-type family Id a :: *
-```
-
 Type family instances
 
 ```haskell
 type instance Id Int = Int
-```
-
-Type family dependencies
-
-```haskell
-type family Id a = r | r -> a
 ```
 
 Binding implicit parameters

--- a/TESTS.md
+++ b/TESTS.md
@@ -253,14 +253,6 @@ Type family instances
 type instance Id Int = Int
 ```
 
-Binding implicit parameters
-
-```haskell
-f =
-  let ?x = 42
-   in f
-```
-
 ### List comprehensions
 
 Short
@@ -458,6 +450,14 @@ f'' ((Data.List.NonEmpty.:|) x _) = x
 g (x:xs) = x
 
 g' ((:) x _) = x
+```
+
+Binding implicit parameters
+
+```haskell
+f =
+  let ?x = 42
+   in f
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -366,6 +366,18 @@ Type family instances
 type instance Id Int = Int
 ```
 
+Multi-way if
+
+``` haskell
+x =
+  if | x <- Just x,
+       x <- Just x ->
+       case x of
+         Just x -> e
+         Nothing -> p
+     | otherwise -> e
+```
+
 ### List comprehensions
 
 Short
@@ -640,18 +652,6 @@ f x
   | otherwise = do e
   where
     x = y
-```
-
-Multi-way if
-
-``` haskell
-x =
-  if | x <- Just x,
-       x <- Just x ->
-       case x of
-         Just x -> e
-         Nothing -> p
-     | otherwise -> e
 ```
 
 Case inside a `where` and `do`

--- a/TESTS.md
+++ b/TESTS.md
@@ -193,34 +193,6 @@ type MyContext m
 
 ## Expressions
 
-List comprehensions, short
-
-``` haskell
-map f xs = [f x | x <- xs]
-```
-
-List comprehensions, long
-
-``` haskell
-defaultExtensions =
-  [ e
-  | EnableExtension {extensionField1 = extensionField1} <-
-      knownExtensions knownExtensions
-  , let a = b
-    -- comment
-  , let c = d
-    -- comment
-  ]
-```
-
-List comprehensions with operators
-
-```haskell
-defaultExtensions =
-  [e | e@EnableExtension {} <- knownExtensions] \\
-  map EnableExtension badExtensions
-```
-
 Parallel list comprehension, short
 
 ```haskell
@@ -430,6 +402,36 @@ Closed type families
 ```haskell
 type family Closed (a :: k) :: Bool where
   Closed x = 'True
+```
+
+### List comprehensions
+
+Short
+
+```haskell
+map f xs = [f x | x <- xs]
+```
+
+Long
+
+```haskell
+defaultExtensions =
+  [ e
+  | EnableExtension {extensionField1 = extensionField1} <-
+      knownExtensions knownExtensions
+  , let a = b
+    -- comment
+  , let c = d
+    -- comment
+  ]
+```
+
+With operators
+
+```haskell
+defaultExtensions =
+  [e | e@EnableExtension {} <- knownExtensions] \\
+  map EnableExtension badExtensions
 ```
 
 ### Lambda expressions

--- a/TESTS.md
+++ b/TESTS.md
@@ -132,6 +132,19 @@ import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 
 ## Declarations
 
+### Class declarations
+
+Default signatures
+
+```haskell
+-- https://github.com/chrisdone/hindent/issues/283
+class Foo a where
+  bar :: a -> a -> a
+  default bar :: Monoid a =>
+    a -> a -> a
+  bar = mappend
+```
+
 ### Class instance declarations
 
 Without declarations
@@ -168,6 +181,106 @@ data Ty :: (* -> *) where
        , field2 :: Bool}
     -> Ty Bool
   TCon' :: (a :: *) -> a -> Ty a
+```
+
+### Function signatures
+
+Type declaration with infix promoted type constructor
+
+```haskell
+fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
+fun1 = undefined
+
+fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
+fun2 = undefined
+```
+
+Long argument list should line break
+
+```haskell
+longLongFunction ::
+     ReaderT r (WriterT w (StateT s m)) a
+  -> StateT s (WriterT w (ReaderT r m)) a
+```
+
+Class constraints should leave `::` on same line
+
+``` haskell
+-- see https://github.com/chrisdone/hindent/pull/266#issuecomment-244182805
+fun ::
+     (Class a, Class b)
+  => fooooooooooo bar mu zot
+  -> fooooooooooo bar mu zot
+  -> c
+```
+
+Class constraints
+
+``` haskell
+fun :: (Class a, Class b) => a -> b -> c
+```
+
+Symbol class constructor in class constraint
+
+```haskell
+f :: (a :?: b) => (a, b)
+f' :: ((:?:) a b) => (a, b)
+```
+
+Tuples
+
+``` haskell
+fun :: (a, b, c) -> (a, b)
+```
+
+Quasiquotes in types
+
+```haskell
+fun :: [a|bc|]
+```
+
+Implicit parameters
+
+```haskell
+f :: (?x :: Int) => Int
+```
+
+Symbol type constructor
+
+```haskell
+f :: a :?: b
+f' :: (:?:) a b
+```
+
+Promoted list (issue #348)
+
+```haskell
+a :: A '[ 'True]
+a = undefined
+
+-- nested promoted list with multiple elements.
+b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
+b = undefined
+```
+
+Promoted list with a tuple (issue #348)
+
+```haskell
+a :: A '[ '( a, b, c, d)]
+a = undefined
+
+-- nested promoted tuples.
+b :: A '[ '( 'True, 'False, '[], '( 'False, 'True))]
+b = undefined
+```
+
+Prefix promoted symbol type constructor
+
+```haskell
+a :: '(T.:->) 'True 'False
+b :: (T.:->) 'True 'False
+c :: '(:->) 'True 'False
+d :: (:->) 'True 'False
 ```
 
 ### Type families
@@ -495,117 +608,6 @@ g =
   case x of
     $(mkPat y z) -> True
     _ -> False
-```
-
-### Function signatures
-
-Type declaration with infix promoted type constructor
-
-```haskell
-fun1 :: Def ('[ Ref s (Stored Uint32), IBool] 'T.:-> IBool)
-fun1 = undefined
-
-fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
-fun2 = undefined
-```
-
-Long argument list should line break
-
-```haskell
-longLongFunction ::
-     ReaderT r (WriterT w (StateT s m)) a
-  -> StateT s (WriterT w (ReaderT r m)) a
-```
-
-Class constraints should leave `::` on same line
-
-``` haskell
--- see https://github.com/chrisdone/hindent/pull/266#issuecomment-244182805
-fun ::
-     (Class a, Class b)
-  => fooooooooooo bar mu zot
-  -> fooooooooooo bar mu zot
-  -> c
-```
-
-Class constraints
-
-``` haskell
-fun :: (Class a, Class b) => a -> b -> c
-```
-
-Symbol class constructor in class constraint
-
-```haskell
-f :: (a :?: b) => (a, b)
-f' :: ((:?:) a b) => (a, b)
-```
-
-Tuples
-
-``` haskell
-fun :: (a, b, c) -> (a, b)
-```
-
-Quasiquotes in types
-
-```haskell
-fun :: [a|bc|]
-```
-
-Default signatures
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/283
-class Foo a where
-  bar :: a -> a -> a
-  default bar :: Monoid a =>
-    a -> a -> a
-  bar = mappend
-```
-
-Implicit parameters
-
-```haskell
-f :: (?x :: Int) => Int
-```
-
-Symbol type constructor
-
-```haskell
-f :: a :?: b
-f' :: (:?:) a b
-```
-
-Promoted list (issue #348)
-
-```haskell
-a :: A '[ 'True]
-a = undefined
-
--- nested promoted list with multiple elements.
-b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
-b = undefined
-```
-
-Promoted list with a tuple (issue #348)
-
-```haskell
-a :: A '[ '( a, b, c, d)]
-a = undefined
-
--- nested promoted tuples.
-b :: A '[ '( 'True, 'False, '[], '( 'False, 'True))]
-b = undefined
-```
-
-Prefix promoted symbol type constructor
-
-```haskell
-a :: '(T.:->) 'True 'False
-b :: (T.:->) 'True 'False
-c :: '(:->) 'True 'False
-d :: (:->) 'True 'False
 ```
 
 ## Function declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -183,6 +183,70 @@ data Ty :: (* -> *) where
   TCon' :: (a :: *) -> a -> Ty a
 ```
 
+Data declarations
+
+``` haskell
+data Tree a
+  = Branch !a !(Tree a) !(Tree a)
+  | Leaf
+
+data Tree a
+  = Branch
+      !a
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+  | Leaf
+
+data HttpException
+  = InvalidStatusCode Int
+  | MissingContentHeader
+
+data Person =
+  Person
+    { firstName :: !String -- ^ First name
+    , lastName :: !String -- ^ Last name
+    , age :: !Int -- ^ Age
+    }
+
+data Expression a
+  = VariableExpression
+      { id :: Id Expression
+      , label :: a
+      }
+  | FunctionExpression
+      { var :: Id Expression
+      , body :: Expression a
+      , label :: a
+      }
+  | ApplyExpression
+      { func :: Expression a
+      , arg :: Expression a
+      , label :: a
+      }
+  | ConstructorExpression
+      { id :: Id Constructor
+      , label :: a
+      }
+```
+
+Spaces between deriving classes
+
+``` haskell
+-- From https://github.com/chrisdone/hindent/issues/167
+data Person =
+  Person
+    { firstName :: !String -- ^ First name
+    , lastName :: !String -- ^ Last name
+    , age :: !Int -- ^ Age
+    }
+  deriving (Eq, Show)
+```
+
 ### Function signatures
 
 Type declaration with infix promoted type constructor
@@ -812,70 +876,6 @@ filter _ [] = []
 filter p (x:xs)
   | p x = x : filter p xs
   | otherwise = filter p xs
-```
-
-Data declarations
-
-``` haskell
-data Tree a
-  = Branch !a !(Tree a) !(Tree a)
-  | Leaf
-
-data Tree a
-  = Branch
-      !a
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-  | Leaf
-
-data HttpException
-  = InvalidStatusCode Int
-  | MissingContentHeader
-
-data Person =
-  Person
-    { firstName :: !String -- ^ First name
-    , lastName :: !String -- ^ Last name
-    , age :: !Int -- ^ Age
-    }
-
-data Expression a
-  = VariableExpression
-      { id :: Id Expression
-      , label :: a
-      }
-  | FunctionExpression
-      { var :: Id Expression
-      , body :: Expression a
-      , label :: a
-      }
-  | ApplyExpression
-      { func :: Expression a
-      , arg :: Expression a
-      , label :: a
-      }
-  | ConstructorExpression
-      { id :: Id Constructor
-      , label :: a
-      }
-```
-
-Spaces between deriving classes
-
-``` haskell
--- From https://github.com/chrisdone/hindent/issues/167
-data Person =
-  Person
-    { firstName :: !String -- ^ First name
-    , lastName :: !String -- ^ Last name
-    , age :: !Int -- ^ Age
-    }
-  deriving (Eq, Show)
 ```
 
 Hanging lambdas


### PR DESCRIPTION
Currently, the test suite file does not have enough sections, making it difficult to read and unclear where to add a new test code. Also, the regression test section is now a jumble of various tests. Therefore, this PR breaks up sections into smaller ones and moves the tests in the regression test section to the appropriate one.