### PR TITLE
Reorganize tests related to data declarations

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -259,6 +259,14 @@ instance (:?:) Int Bool
 
 ### Data declarations
 
+Unbanged fields
+
+```haskell
+data HttpException
+  = InvalidStatusCode Int
+  | MissingContentHeader
+```
+
 Multiple unnamed fields
 
 ```haskell
@@ -297,10 +305,6 @@ data Ty :: (* -> *) where
 Data declarations
 
 ```haskell
-data HttpException
-  = InvalidStatusCode Int
-  | MissingContentHeader
-
 data Person =
   Person
     { firstName :: !String -- ^ First name

--- a/TESTS.md
+++ b/TESTS.md
@@ -273,6 +273,13 @@ data HttpException
   | MissingContentHeader
 ```
 
+A bang field
+
+```haskell
+data Foo =
+  Foo !Int
+```
+
 Multiple unnamed fields
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -1636,30 +1636,6 @@ rec = undefined
 mdo = undefined
 ```
 
-sophie-h Record syntax change in 5.2.2 #393
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/393
-data X
-  = X
-      { x :: Int
-      }
-  | X'
-
-data X =
-  X
-    { x :: Int
-    , x' :: Int
-    }
-
-data X
-  = X
-      { x :: Int
-      , x' :: Int
-      }
-  | X'
-```
-
 k-bx Infix data constructor gets reformatted into a parse error #328
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -268,6 +268,9 @@ Prefix
 instance (:?:) Int Bool
 ```
 
+### Data declarations
+
+
 ### Type synonym declarations
 
 Short

--- a/TESTS.md
+++ b/TESTS.md
@@ -356,15 +356,6 @@ data Foo =
   Int :--> Int
 ```
 
-A field with a `forall` constraint
-
-```haskell
--- https://github.com/mihaimaruseac/hindent/issues/278
-data Link c1 c2 a c =
-  forall b. (c1 a b, c2 b c) =>
-            Link (Proxy b)
-```
-
 GADT declarations
 
 ```haskell
@@ -374,6 +365,27 @@ data Ty :: (* -> *) where
        , field2 :: Bool}
     -> Ty Bool
   TCon' :: (a :: *) -> a -> Ty a
+```
+
+#### Fields with `forall` constraints
+
+Single
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/278
+data Link c1 c2 a c =
+  forall b. (c1 a b, c2 b c) =>
+            Link (Proxy b)
+```
+
+Multiple
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/443
+{-# LANGUAGE ExistentialQuantification #-}
+
+data D =
+  forall a b c. D a b c
 ```
 
 #### Derivings
@@ -1775,16 +1787,6 @@ f :: Num a => a
 f = id
 
 x = f @Int 12
-```
-
-DavidEichmann Existential Quantification reordered #443
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/443
-{-# LANGUAGE ExistentialQuantification #-}
-
-data D =
-  forall a b c. D a b c
 ```
 
 michalrus `let ... in ...` inside of `do` breaks compilation #467

--- a/TESTS.md
+++ b/TESTS.md
@@ -315,7 +315,38 @@ data Expression a
       }
 ```
 
-Derivings
+GADT declarations
+
+```haskell
+data Ty :: (* -> *) where
+  TCon
+    :: { field1 :: Int
+       , field2 :: Bool}
+    -> Ty Bool
+  TCon' :: (a :: *) -> a -> Ty a
+```
+
+#### Derivings
+
+With a single constructor
+
+```haskell
+data Simple =
+  Simple
+  deriving (Show)
+```
+
+With multiple constructors
+
+```haskell
+data Stuffs
+  = Things
+  | This
+  | That
+  deriving (Show)
+```
+
+With a record constructor
 
 ```haskell
 -- From https://github.com/mihaimaruseac/hindent/issues/167
@@ -326,17 +357,6 @@ data Person =
     , age :: !Int -- ^ Age
     }
   deriving (Eq, Show)
-```
-
-GADT declarations
-
-```haskell
-data Ty :: (* -> *) where
-  TCon
-    :: { field1 :: Int
-       , field2 :: Bool}
-    -> Ty Bool
-  TCon' :: (a :: *) -> a -> Ty a
 ```
 
 ### Type synonym declarations
@@ -1441,20 +1461,6 @@ import B
 ```haskell expect
 import ATooLongList (alpha, beta, delta, epsilon, eta, gamma, theta, zeta)
 import B
-```
-
-radupopescu `deriving` keyword not aligned with pipe symbol for type declarations
-
-``` haskell
-data Stuffs
-  = Things
-  | This
-  | That
-  deriving (Show)
-
-data Simple =
-  Simple
-  deriving (Show)
 ```
 
 sgraf812 top-level pragmas should not add an additional newline #255

--- a/TESTS.md
+++ b/TESTS.md
@@ -259,6 +259,12 @@ instance (:?:) Int Bool
 
 ### Data declarations
 
+No fields
+
+```haskell
+data Foo
+```
+
 Unbanged fields
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -265,7 +265,7 @@ No fields
 data Foo
 ```
 
-Unbanged fields
+Multiple unnamed fields
 
 ```haskell
 data HttpException

--- a/TESTS.md
+++ b/TESTS.md
@@ -259,6 +259,14 @@ instance (:?:) Int Bool
 
 ### Data declarations
 
+Multiple unnamed fields
+
+```haskell
+data Tree a
+  = Branch !a !(Tree a) !(Tree a)
+  | Leaf
+```
+
 GADT declarations
 
 ```haskell
@@ -272,11 +280,7 @@ data Ty :: (* -> *) where
 
 Data declarations
 
-``` haskell
-data Tree a
-  = Branch !a !(Tree a) !(Tree a)
-  | Leaf
-
+```haskell
 data Tree a
   = Branch
       !a

--- a/TESTS.md
+++ b/TESTS.md
@@ -315,6 +315,19 @@ data Expression a
       }
 ```
 
+Derivings
+
+```haskell
+-- From https://github.com/mihaimaruseac/hindent/issues/167
+data Person =
+  Person
+    { firstName :: !String -- ^ First name
+    , lastName :: !String -- ^ Last name
+    , age :: !Int -- ^ Age
+    }
+  deriving (Eq, Show)
+```
+
 GADT declarations
 
 ```haskell
@@ -1021,19 +1034,6 @@ filter _ [] = []
 filter p (x:xs)
   | p x = x : filter p xs
   | otherwise = filter p xs
-```
-
-Spaces between deriving classes
-
-``` haskell
--- From https://github.com/chrisdone/hindent/issues/167
-data Person =
-  Person
-    { firstName :: !String -- ^ First name
-    , lastName :: !String -- ^ Last name
-    , age :: !Int -- ^ Age
-    }
-  deriving (Eq, Show)
 ```
 
 Hanging lambdas

--- a/TESTS.md
+++ b/TESTS.md
@@ -315,6 +315,15 @@ data Expression a
       }
 ```
 
+A field with a `forall` constraint
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/278
+data Link c1 c2 a c =
+  forall b. (c1 a b, c2 b c) =>
+            Link (Proxy b)
+```
+
 GADT declarations
 
 ```haskell
@@ -1470,15 +1479,6 @@ sgraf812 top-level pragmas should not add an additional newline #255
 {-# INLINE f #-}
 f :: Int -> Int
 f n = n
-```
-
-ivan-timokhin variables swapped around in constraints #278
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/278
-data Link c1 c2 a c =
-  forall b. (c1 a b, c2 b c) =>
-            Link (Proxy b)
 ```
 
 ttuegel qualified infix sections get mangled #273

--- a/TESTS.md
+++ b/TESTS.md
@@ -273,27 +273,29 @@ data HttpException
   | MissingContentHeader
 ```
 
+A lot of unnamed fields in a constructor
+
+```haskell
+data Foo =
+  Foo
+    String
+    String
+    String
+    String
+    String
+    String
+    String
+    String
+    String
+    String
+    String
+```
+
 A banged field
 
 ```haskell
 data Foo =
   Foo !Int
-```
-
-A lot of unnamed fields in a constructor
-
-```haskell
-data Tree a
-  = Branch
-      !a
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-  | Leaf
 ```
 
 Multiple constructors with fields

--- a/TESTS.md
+++ b/TESTS.md
@@ -280,14 +280,6 @@ data Foo =
   Foo !Int
 ```
 
-Multiple unnamed fields
-
-```haskell
-data Tree a
-  = Branch !a !(Tree a) !(Tree a)
-  | Leaf
-```
-
 A lot of unnamed fields in a constructor
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -305,6 +305,15 @@ data Foo =
   Foo !Int
 ```
 
+A record constructor with a field
+
+```haskell
+data Foo =
+  Foo
+    { foo :: Int
+    }
+```
+
 Multiple constructors with fields
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -291,18 +291,7 @@ data Tree a
   | Leaf
 ```
 
-GADT declarations
-
-```haskell
-data Ty :: (* -> *) where
-  TCon
-    :: { field1 :: Int
-       , field2 :: Bool}
-    -> Ty Bool
-  TCon' :: (a :: *) -> a -> Ty a
-```
-
-Data declarations
+Multiple constructors with fields
 
 ```haskell
 data Expression a
@@ -324,6 +313,17 @@ data Expression a
       { id :: Id Constructor
       , label :: a
       }
+```
+
+GADT declarations
+
+```haskell
+data Ty :: (* -> *) where
+  TCon
+    :: { field1 :: Int
+       , field2 :: Bool}
+    -> Ty Bool
+  TCon' :: (a :: *) -> a -> Ty a
 ```
 
 ### Type synonym declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -267,6 +267,22 @@ data Tree a
   | Leaf
 ```
 
+A lot of unnamed fields in a constructor
+
+```haskell
+data Tree a
+  = Branch
+      !a
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+  | Leaf
+```
+
 GADT declarations
 
 ```haskell
@@ -281,18 +297,6 @@ data Ty :: (* -> *) where
 Data declarations
 
 ```haskell
-data Tree a
-  = Branch
-      !a
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-  | Leaf
-
 data HttpException
   = InvalidStatusCode Int
   | MissingContentHeader

--- a/TESTS.md
+++ b/TESTS.md
@@ -265,6 +265,13 @@ No fields
 data Foo
 ```
 
+Single field
+
+```haskell
+data Foo =
+  Foo
+```
+
 Multiple unnamed fields
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -338,6 +338,17 @@ data Expression a
       }
 ```
 
+A mixture of constructors with unnamed fields and record constructors
+
+```haskell
+data X
+  = X
+      { x :: Int
+      , x' :: Int
+      }
+  | X'
+```
+
 A field with a `forall` constraint
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -273,7 +273,7 @@ data HttpException
   | MissingContentHeader
 ```
 
-A bang field
+A banged field
 
 ```haskell
 data Foo =

--- a/TESTS.md
+++ b/TESTS.md
@@ -305,13 +305,6 @@ data Ty :: (* -> *) where
 Data declarations
 
 ```haskell
-data Person =
-  Person
-    { firstName :: !String -- ^ First name
-    , lastName :: !String -- ^ Last name
-    , age :: !Int -- ^ Age
-    }
-
 data Expression a
   = VariableExpression
       { id :: Id Expression

--- a/TESTS.md
+++ b/TESTS.md
@@ -349,6 +349,13 @@ data X
   | X'
 ```
 
+An infix data constructor
+
+```haskell
+data Foo =
+  Int :--> Int
+```
+
 A field with a `forall` constraint
 
 ```haskell
@@ -1634,15 +1641,6 @@ RecursiveDo `rec` and `mdo` keyword #328
 rec = undefined
 
 mdo = undefined
-```
-
-k-bx Infix data constructor gets reformatted into a parse error #328
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/328
-data Expect =
-  String :--> String
-  deriving (Show)
 ```
 
 tfausak Class constraints cause too many newlines #244

--- a/TESTS.md
+++ b/TESTS.md
@@ -270,6 +270,57 @@ data Ty :: (* -> *) where
   TCon' :: (a :: *) -> a -> Ty a
 ```
 
+Data declarations
+
+``` haskell
+data Tree a
+  = Branch !a !(Tree a) !(Tree a)
+  | Leaf
+
+data Tree a
+  = Branch
+      !a
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+      !(Tree a)
+  | Leaf
+
+data HttpException
+  = InvalidStatusCode Int
+  | MissingContentHeader
+
+data Person =
+  Person
+    { firstName :: !String -- ^ First name
+    , lastName :: !String -- ^ Last name
+    , age :: !Int -- ^ Age
+    }
+
+data Expression a
+  = VariableExpression
+      { id :: Id Expression
+      , label :: a
+      }
+  | FunctionExpression
+      { var :: Id Expression
+      , body :: Expression a
+      , label :: a
+      }
+  | ApplyExpression
+      { func :: Expression a
+      , arg :: Expression a
+      , label :: a
+      }
+  | ConstructorExpression
+      { id :: Id Constructor
+      , label :: a
+      }
+```
+
 ### Type synonym declarations
 
 Short
@@ -965,57 +1016,6 @@ filter _ [] = []
 filter p (x:xs)
   | p x = x : filter p xs
   | otherwise = filter p xs
-```
-
-Data declarations
-
-``` haskell
-data Tree a
-  = Branch !a !(Tree a) !(Tree a)
-  | Leaf
-
-data Tree a
-  = Branch
-      !a
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-      !(Tree a)
-  | Leaf
-
-data HttpException
-  = InvalidStatusCode Int
-  | MissingContentHeader
-
-data Person =
-  Person
-    { firstName :: !String -- ^ First name
-    , lastName :: !String -- ^ Last name
-    , age :: !Int -- ^ Age
-    }
-
-data Expression a
-  = VariableExpression
-      { id :: Id Expression
-      , label :: a
-      }
-  | FunctionExpression
-      { var :: Id Expression
-      , body :: Expression a
-      , label :: a
-      }
-  | ApplyExpression
-      { func :: Expression a
-      , arg :: Expression a
-      , label :: a
-      }
-  | ConstructorExpression
-      { id :: Id Constructor
-      , label :: a
-      }
 ```
 
 Spaces between deriving classes

--- a/TESTS.md
+++ b/TESTS.md
@@ -142,17 +142,6 @@ fun2 :: Def ('[ Ref s (Stored Uint32), IBool] ':-> IBool)
 fun2 = undefined
 ```
 
-GADT declarations
-
-```haskell
-data Ty :: (* -> *) where
-  TCon
-    :: { field1 :: Int
-       , field2 :: Bool}
-    -> Ty Bool
-  TCon' :: (a :: *) -> a -> Ty a
-```
-
 ### Class declarations
 
 Default signatures
@@ -270,6 +259,16 @@ instance (:?:) Int Bool
 
 ### Data declarations
 
+GADT declarations
+
+```haskell
+data Ty :: (* -> *) where
+  TCon
+    :: { field1 :: Int
+       , field2 :: Bool}
+    -> Ty Bool
+  TCon' :: (a :: *) -> a -> Ty a
+```
 
 ### Type synonym declarations
 


### PR DESCRIPTION
This PR does the following things.
- It creates the "Data declarations" section and a few subsections.
- It moves tests related to data declarations into appropriate sections.
- It splits large test cases.
- It simplifies complex test cases, e.g., removing unnecessary parts from a test case.
- It adds missing test cases.

This is a part of #610.
