### PR TITLE
Reorganize tests related to list comprehensions

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -534,14 +534,6 @@ class A where
 
 ## Expressions
 
-List comprehensions with operators
-
-```haskell
-defaultExtensions =
-  [e | e@EnableExtension {} <- knownExtensions] \\
-  map EnableExtension badExtensions
-```
-
 Parallel list comprehension, short
 
 ```haskell
@@ -799,6 +791,14 @@ defaultExtensions =
   , let c = d
     -- comment
   ]
+```
+
+With operators
+
+```haskell
+defaultExtensions =
+  [e | e@EnableExtension {} <- knownExtensions] \\
+  map EnableExtension badExtensions
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -799,6 +799,9 @@ foo =
       cFunction fooo barrr muuu (fooo barrr muuu) (fooo barrr muuu)
 ```
 
+### List comprehensions
+
+
 ## Template Haskell
 
 Expression brackets

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,12 +534,6 @@ class A where
 
 ## Expressions
 
-List comprehensions, short
-
-``` haskell
-map f xs = [f x | x <- xs]
-```
-
 List comprehensions, long
 
 ``` haskell
@@ -801,7 +795,11 @@ foo =
 
 ### List comprehensions
 
+Short
 
+```haskell
+map f xs = [f x | x <- xs]
+```
 ## Template Haskell
 
 Expression brackets

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,19 +534,6 @@ class A where
 
 ## Expressions
 
-Parallel list comprehension, long
-
-```haskell
-fun xs ys =
-  [ (alphaBetaGamma, deltaEpsilonZeta)
-  | x <- xs
-  , z <- zs
-  | y <- ys
-  , cond
-  , let t = t
-  ]
-```
-
 Record, short
 
 ``` haskell
@@ -801,6 +788,19 @@ Parallel list comprehension, short
 
 ```haskell
 zip xs ys = [(x, y) | x <- xs | y <- ys]
+```
+
+Long
+
+```haskell
+fun xs ys =
+  [ (alphaBetaGamma, deltaEpsilonZeta)
+  | x <- xs
+  , z <- zs
+  | y <- ys
+  , cond
+  , let t = t
+  ]
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -663,22 +663,6 @@ Type application
 fun @Int 12
 ```
 
-Transform list comprehensions
-
-```haskell
-list =
-  [ (x, y, map the v)
-  | x <- [1 .. 10]
-  , y <- [1 .. 10]
-  , let v = x + y
-  , then group by v using groupWith
-  , then take 10
-  , then group using permutations
-  , t <- concat v
-  , then takeWhile by t < 3
-  ]
-```
-
 Type families
 
 ```haskell
@@ -797,6 +781,22 @@ With operators
 defaultExtensions =
   [e | e@EnableExtension {} <- knownExtensions] \\
   map EnableExtension badExtensions
+```
+
+Transform list comprehensions
+
+```haskell
+list =
+  [ (x, y, map the v)
+  | x <- [1 .. 10]
+  , y <- [1 .. 10]
+  , let v = x + y
+  , then group by v using groupWith
+  , then take 10
+  , then group using permutations
+  , t <- concat v
+  , then takeWhile by t < 3
+  ]
 ```
 
 #### Parallel list comprehensions

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,20 +534,6 @@ class A where
 
 ## Expressions
 
-List comprehensions, long
-
-``` haskell
-defaultExtensions =
-  [ e
-  | EnableExtension {extensionField1 = extensionField1} <-
-      knownExtensions knownExtensions
-  , let a = b
-    -- comment
-  , let c = d
-    -- comment
-  ]
-```
-
 List comprehensions with operators
 
 ```haskell
@@ -800,6 +786,21 @@ Short
 ```haskell
 map f xs = [f x | x <- xs]
 ```
+
+Long
+
+```haskell
+defaultExtensions =
+  [ e
+  | EnableExtension {extensionField1 = extensionField1} <-
+      knownExtensions knownExtensions
+  , let a = b
+    -- comment
+  , let c = d
+    -- comment
+  ]
+```
+
 ## Template Haskell
 
 Expression brackets

--- a/TESTS.md
+++ b/TESTS.md
@@ -784,7 +784,7 @@ defaultExtensions =
 
 #### Parallel list comprehensions
 
-Parallel list comprehension, short
+Short
 
 ```haskell
 zip xs ys = [(x, y) | x <- xs | y <- ys]

--- a/TESTS.md
+++ b/TESTS.md
@@ -774,6 +774,23 @@ defaultExtensions =
   ]
 ```
 
+Another long one
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/357
+foo =
+  [ (x, y)
+  | x <- [1 .. 10]
+  , y <- [11 .. 20]
+  , even x
+  , even x
+  , even x
+  , even x
+  , even x
+  , odd y
+  ]
+```
+
 With operators
 
 ```haskell
@@ -1621,23 +1638,6 @@ neongreen "{" is lost when formatting "Foo{}" #366
 ```haskell
 -- https://github.com/chrisdone/hindent/issues/366
 foo = Nothing {}
-```
-
-jparoz Trailing space in list comprehension #357
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/357
-foo =
-  [ (x, y)
-  | x <- [1 .. 10]
-  , y <- [11 .. 20]
-  , even x
-  , even x
-  , even x
-  , even x
-  , even x
-  , odd y
-  ]
 ```
 
 ttuegel Record formatting applied to expressions with RecordWildCards #274

--- a/TESTS.md
+++ b/TESTS.md
@@ -801,6 +801,8 @@ defaultExtensions =
   map EnableExtension badExtensions
 ```
 
+#### Parallel list comprehensions
+
 ## Template Haskell
 
 Expression brackets

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,12 +534,6 @@ class A where
 
 ## Expressions
 
-Parallel list comprehension, short
-
-```haskell
-zip xs ys = [(x, y) | x <- xs | y <- ys]
-```
-
 Parallel list comprehension, long
 
 ```haskell
@@ -802,6 +796,12 @@ defaultExtensions =
 ```
 
 #### Parallel list comprehensions
+
+Parallel list comprehension, short
+
+```haskell
+zip xs ys = [(x, y) | x <- xs | y <- ys]
+```
 
 ## Template Haskell
 


### PR DESCRIPTION
This PR creates the "List comprehensions" and a subsection and moves tests related to list comprehensions inside them.

This is a part of #610.
