### PR TITLE
Reorganize tests related to record expressions

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -808,6 +808,24 @@ commitToEvent gitFolderPath timezone commit =
     }
 ```
 
+Another long one
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/358
+foo =
+  assert
+    sanityCheck
+    BomSnapshotAggr
+      { snapshot = Just bs
+      , previousId = M.bomSnapshotHistoryPreviousId . entityVal <$> bsp
+      , nextId = M.bomSnapshotHistoryNextId . entityVal <$> bsn
+      , bomEx = bx''
+      , orderSubstitutes =
+          S.fromList . map OrderSubstituteAggrByCreatedAtAsc $ subs
+      , snapshotSubstitute = msub
+      }
+```
+
 Symbol constructor
 
 ```haskell
@@ -1595,23 +1613,6 @@ newtype Foo =
            , Foldable
            , Traversable
            )
-```
-
-Indents record constructions and updates #358
-
-```haskell
-foo =
-  assert
-    sanityCheck
-    BomSnapshotAggr
-      { snapshot = Just bs
-      , previousId = M.bomSnapshotHistoryPreviousId . entityVal <$> bsp
-      , nextId = M.bomSnapshotHistoryNextId . entityVal <$> bsn
-      , bomEx = bx''
-      , orderSubstitutes =
-          S.fromList . map OrderSubstituteAggrByCreatedAtAsc $ subs
-      , snapshotSubstitute = msub
-      }
 ```
 
 paraseba Deriving strategies with multiple deriving clauses

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,14 +534,6 @@ class A where
 
 ## Expressions
 
-Record, short
-
-``` haskell
-getGitProvider :: EventProvider GitRecord ()
-getGitProvider =
-  EventProvider {getModuleName = "Git", getEvents = getRepoCommits}
-```
-
 Record, medium
 
 ``` haskell
@@ -801,6 +793,13 @@ list =
 
 ### Records
 
+Short
+
+``` haskell
+getGitProvider :: EventProvider GitRecord ()
+getGitProvider =
+  EventProvider {getModuleName = "Git", getEvents = getRepoCommits}
+```
 
 #### Parallel list comprehensions
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,14 +534,6 @@ class A where
 
 ## Expressions
 
-Record with symbol field
-
-```haskell
-f x = x {(..?) = wat}
-
-g x = Rec {(..?)}
-```
-
 Cases
 
 ``` haskell
@@ -820,6 +812,14 @@ Symbol constructor
 
 ```haskell
 f = (:..?) {}
+```
+
+Symbol field
+
+```haskell
+f x = x {(..?) = wat}
+
+g x = Rec {(..?)}
 ```
 
 ## Template Haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,18 +534,6 @@ class A where
 
 ## Expressions
 
-Record, long
-
-``` haskell
-commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
-commitToEvent gitFolderPath timezone commit =
-  Event.Event
-    { pluginName = getModuleName getGitProvider
-    , eventIcon = "glyphicon-cog"
-    , eventDate = localTimeToUTC timezone (commitDate commit)
-    }
-```
-
 Record with symbol constructor
 
 ```haskell
@@ -799,6 +787,18 @@ commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
 commitToEvent gitFolderPath timezone commit =
   Event.Event
     {pluginName = getModuleName getGitProvider, eventIcon = "glyphicon-cog"}
+```
+
+Long
+
+```haskell
+commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
+commitToEvent gitFolderPath timezone commit =
+  Event.Event
+    { pluginName = getModuleName getGitProvider
+    , eventIcon = "glyphicon-cog"
+    , eventDate = localTimeToUTC timezone (commitDate commit)
+    }
 ```
 
 #### Parallel list comprehensions

--- a/TESTS.md
+++ b/TESTS.md
@@ -795,7 +795,7 @@ list =
 
 Short
 
-``` haskell
+```haskell
 getGitProvider :: EventProvider GitRecord ()
 getGitProvider =
   EventProvider {getModuleName = "Git", getEvents = getRepoCommits}

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,15 +534,6 @@ class A where
 
 ## Expressions
 
-Record, medium
-
-``` haskell
-commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
-commitToEvent gitFolderPath timezone commit =
-  Event.Event
-    {pluginName = getModuleName getGitProvider, eventIcon = "glyphicon-cog"}
-```
-
 Record, long
 
 ``` haskell
@@ -799,6 +790,15 @@ Short
 getGitProvider :: EventProvider GitRecord ()
 getGitProvider =
   EventProvider {getModuleName = "Git", getEvents = getRepoCommits}
+```
+
+Medium
+
+```haskell
+commitToEvent :: FolderPath -> TimeZone -> Commit -> Event.Event
+commitToEvent gitFolderPath timezone commit =
+  Event.Event
+    {pluginName = getModuleName getGitProvider, eventIcon = "glyphicon-cog"}
 ```
 
 #### Parallel list comprehensions

--- a/TESTS.md
+++ b/TESTS.md
@@ -799,6 +799,9 @@ list =
   ]
 ```
 
+### Records
+
+
 #### Parallel list comprehensions
 
 Short

--- a/TESTS.md
+++ b/TESTS.md
@@ -534,12 +534,6 @@ class A where
 
 ## Expressions
 
-Record with symbol constructor
-
-```haskell
-f = (:..?) {}
-```
-
 Record with symbol field
 
 ```haskell
@@ -799,6 +793,12 @@ commitToEvent gitFolderPath timezone commit =
     , eventIcon = "glyphicon-cog"
     , eventDate = localTimeToUTC timezone (commitDate commit)
     }
+```
+
+Symbol constructor
+
+```haskell
+f = (:..?) {}
 ```
 
 #### Parallel list comprehensions

--- a/TESTS.md
+++ b/TESTS.md
@@ -764,6 +764,27 @@ list =
   ]
 ```
 
+#### Parallel list comprehensions
+
+Short
+
+```haskell
+zip xs ys = [(x, y) | x <- xs | y <- ys]
+```
+
+Long
+
+```haskell
+fun xs ys =
+  [ (alphaBetaGamma, deltaEpsilonZeta)
+  | x <- xs
+  , z <- zs
+  | y <- ys
+  , cond
+  , let t = t
+  ]
+```
+
 ### Records
 
 Short
@@ -799,27 +820,6 @@ Symbol constructor
 
 ```haskell
 f = (:..?) {}
-```
-
-#### Parallel list comprehensions
-
-Short
-
-```haskell
-zip xs ys = [(x, y) | x <- xs | y <- ys]
-```
-
-Long
-
-```haskell
-fun xs ys =
-  [ (alphaBetaGamma, deltaEpsilonZeta)
-  | x <- xs
-  , z <- zs
-  | y <- ys
-  , cond
-  , let t = t
-  ]
 ```
 
 ## Template Haskell


### PR DESCRIPTION
This PR creates the "Records" subsection and its subsections inside the "Expressions" section and moves tests related to record expressions inside them.

This is a part of #610.
