### PR TITLE
Reorganize tests related to operators

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -545,12 +545,6 @@ strToMonth month =
     _ -> error $ "Unknown month " ++ month
 ```
 
-Operator in parentheses
-
-```haskell
-cat = (++)
-```
-
 Symbol data constructor in parentheses
 
 ```haskell
@@ -777,6 +771,12 @@ With lambda-case
 ```haskell
 for xs $ \case
   Left x -> x
+```
+
+In parentheses
+
+```haskell
+cat = (++)
 ```
 
 ### Records

--- a/TESTS.md
+++ b/TESTS.md
@@ -779,6 +779,16 @@ In parentheses
 cat = (++)
 ```
 
+A data constructor enclosed by parentheses
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/422
+data T a =
+  a :@ a
+
+test = (:@)
+```
+
 ### Records
 
 Short
@@ -1763,16 +1773,6 @@ andersk Cannot parse @: operator #421
 a @: b = a + b
 
 main = print (2 @: 2)
-```
-
-andersk Corrupts parenthesized type operators #422
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/422
-data T a =
-  a :@ a
-
-test = (:@)
 ```
 
 NorfairKing Infix constructor pattern is broken #424

--- a/TESTS.md
+++ b/TESTS.md
@@ -779,7 +779,7 @@ In parentheses
 cat = (++)
 ```
 
-`@` can be used to construct an operator unless `TypeApplications` is enabled.
+The first character of an operator can be `@` unless `TypeApplications` is enabled.
 
 ```haskell
 -- https://github.com/mihaimaruseac/hindent/issues/421

--- a/TESTS.md
+++ b/TESTS.md
@@ -545,14 +545,6 @@ strToMonth month =
     _ -> error $ "Unknown month " ++ month
 ```
 
-Operators, good
-
-```haskell pending
-x =
-  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
-  Just thisissolong <*> Just stilllonger <*> evenlonger
-```
-
 Operator with `do`
 
 ```haskell
@@ -777,6 +769,14 @@ x =
   Just thisissolong <*>
   Just stilllonger <*>
   evenlonger
+```
+
+Good
+
+```haskell pending
+x =
+  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
+  Just thisissolong <*> Just stilllonger <*> evenlonger
 ```
 
 ### Records

--- a/TESTS.md
+++ b/TESTS.md
@@ -779,6 +779,15 @@ In parentheses
 cat = (++)
 ```
 
+`@` can be used to construct an operator unless `TypeApplications` is enabled.
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/421
+a @: b = a + b
+
+main = print (2 @: 2)
+```
+
 A data constructor enclosed by parentheses
 
 ```haskell
@@ -1764,15 +1773,6 @@ TimoFreiberg INLINE (and other) pragmas for operators are reformatted without pa
 ```haskell
 -- https://github.com/commercialhaskell/hindent/issues/415
 {-# NOINLINE (<>) #-}
-```
-
-andersk Cannot parse @: operator #421
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/421
-a @: b = a + b
-
-main = print (2 @: 2)
 ```
 
 NorfairKing Infix constructor pattern is broken #424

--- a/TESTS.md
+++ b/TESTS.md
@@ -545,16 +545,6 @@ strToMonth month =
     _ -> error $ "Unknown month " ++ month
 ```
 
-Operators, bad
-
-``` haskell
-x =
-  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
-  Just thisissolong <*>
-  Just stilllonger <*>
-  evenlonger
-```
-
 Operators, good
 
 ```haskell pending
@@ -779,6 +769,15 @@ fun xs ys =
 
 ### Operators
 
+Bad
+
+```haskell
+x =
+  Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
+  Just thisissolong <*>
+  Just stilllonger <*>
+  evenlonger
+```
 
 ### Records
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -545,13 +545,6 @@ strToMonth month =
     _ -> error $ "Unknown month " ++ month
 ```
 
-Operator with lambda-case
-
-```haskell
-for xs $ \case
-  Left x -> x
-```
-
 Operator in parentheses
 
 ```haskell
@@ -777,6 +770,13 @@ With `do`
 for xs $ do
   left x
   right x
+```
+
+With lambda-case
+
+```haskell
+for xs $ \case
+  Left x -> x
 ```
 
 ### Records

--- a/TESTS.md
+++ b/TESTS.md
@@ -545,14 +545,6 @@ strToMonth month =
     _ -> error $ "Unknown month " ++ month
 ```
 
-Operator with `do`
-
-```haskell
-for xs $ do
-  left x
-  right x
-```
-
 Operator with lambda-case
 
 ```haskell
@@ -777,6 +769,14 @@ Good
 x =
   Value <$> thing <*> secondThing <*> thirdThing <*> fourthThing <*>
   Just thisissolong <*> Just stilllonger <*> evenlonger
+```
+
+With `do`
+
+```haskell
+for xs $ do
+  left x
+  right x
 ```
 
 ### Records

--- a/TESTS.md
+++ b/TESTS.md
@@ -777,6 +777,9 @@ fun xs ys =
   ]
 ```
 
+### Operators
+
+
 ### Records
 
 Short

--- a/TESTS.md
+++ b/TESTS.md
@@ -779,7 +779,7 @@ In parentheses
 cat = (++)
 ```
 
-The first character of an operator can be `@` unless `TypeApplications` is enabled.
+The first character of an infix operator can be `@` unless `TypeApplications` is enabled.
 
 ```haskell
 -- https://github.com/mihaimaruseac/hindent/issues/421


### PR DESCRIPTION
This PR creates the "Operators" section, moves tests related to operators inside it, updates some tests' names, and fixes URLs to issues.

This is a part of #610.
