### PR TITLE
Reorganize tests related to type family

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -441,6 +441,13 @@ With injectivity annotations
 type family Id a = r | r -> a
 ```
 
+Closed type families
+
+```haskell
+type family Closed (a :: k) :: Bool where
+  Closed x = 'True
+```
+
 ### Type synonym declarations
 
 Short
@@ -613,13 +620,6 @@ Binding implicit parameters
 f =
   let ?x = 42
    in f
-```
-
-Closed type families
-
-```haskell
-type family Closed (a :: k) :: Bool where
-  Closed x = 'True
 ```
 
 ### Lambda expressions

--- a/TESTS.md
+++ b/TESTS.md
@@ -423,6 +423,11 @@ data Person =
 
 ### Type family declarations
 
+Without annotations
+
+```haskell
+type family Id a
+```
 
 ### Type synonym declarations
 
@@ -582,12 +587,6 @@ Type application
 {-# LANGUAGE TypeApplications #-}
 
 fun @Int 12
-```
-
-Type families
-
-```haskell
-type family Id a
 ```
 
 Type family annotations

--- a/TESTS.md
+++ b/TESTS.md
@@ -429,6 +429,12 @@ Without annotations
 type family Id a
 ```
 
+With annotations
+
+```haskell
+type family Id a :: *
+```
+
 ### Type synonym declarations
 
 Short
@@ -587,12 +593,6 @@ Type application
 {-# LANGUAGE TypeApplications #-}
 
 fun @Int 12
-```
-
-Type family annotations
-
-``` haskell
-type family Id a :: *
 ```
 
 Type family instances

--- a/TESTS.md
+++ b/TESTS.md
@@ -421,6 +421,9 @@ data Person =
   deriving (Eq, Show)
 ```
 
+### Type family declarations
+
+
 ### Type synonym declarations
 
 Short

--- a/TESTS.md
+++ b/TESTS.md
@@ -435,6 +435,12 @@ With annotations
 type family Id a :: *
 ```
 
+With injectivity annotations
+
+```haskell
+type family Id a = r | r -> a
+```
+
 ### Type synonym declarations
 
 Short
@@ -599,12 +605,6 @@ Type family instances
 
 ```haskell
 type instance Id Int = Int
-```
-
-Type family dependencies
-
-```haskell
-type family Id a = r | r -> a
 ```
 
 Binding implicit parameters


### PR DESCRIPTION
This PR creates the "Type family declarations" sections and move tests related to type family declarations inside it.

This is a part of #610.
