### PR TITLE
Reorganize tests related to function declarations

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -458,6 +458,13 @@ g x =
 
 #### Pattern matchings
 
+Multiple matchings
+
+```haskell
+head' [] = Nothing
+head' (x:xs) = Just x
+```
+
 n+k patterns
 
 ```haskell
@@ -1246,25 +1253,6 @@ test
   ,
   , nu81
   ,)
-```
-
-## Johan Tibell compatibility checks
-
-Basic example from Tibbe's style
-
-``` haskell
-sayHello :: IO ()
-sayHello = do
-  name <- getLine
-  putStrLn $ greeting name
-  where
-    greeting name = "Hello, " ++ name ++ "!"
-
-filter :: (a -> Bool) -> [a] -> [a]
-filter _ [] = []
-filter p (x:xs)
-  | p x = x : filter p xs
-  | otherwise = filter p xs
 ```
 
 ## Comments

--- a/TESTS.md
+++ b/TESTS.md
@@ -413,6 +413,13 @@ data Person =
 
 ### Function declarations
 
+Prefix notation for operators
+
+```haskell
+(+) :: Num a => a -> a -> a
+(+) a b = a
+```
+
 #### Pattern matchings
 
 n+k patterns
@@ -1079,13 +1086,6 @@ g =
 ```
 
 ## Function declarations
-
-Prefix notation for operators
-
-``` haskell
-(+) :: Num a => a -> a -> a
-(+) a b = a
-```
 
 Where clause
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -525,6 +525,12 @@ Symbol field
 f (X {(..?) = x}) = x
 ```
 
+Punned symbol field
+
+```haskell
+f' (X {(..?)}) = (..?)
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1240,14 +1246,6 @@ test
   ,
   , nu81
   ,)
-```
-
-## Record syntax
-
-Punned symbol field
-
-```haskell
-f' (X {(..?)}) = (..?)
 ```
 
 ## Johan Tibell compatibility checks

--- a/TESTS.md
+++ b/TESTS.md
@@ -416,7 +416,6 @@ data Person =
 Prefix notation for operators
 
 ```haskell
-(+) :: Num a => a -> a -> a
 (+) a b = a
 ```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -461,7 +461,7 @@ Multiple matchings
 
 ```haskell
 head' [] = Nothing
-head' (x:xs) = Just x
+head' (x:_) = Just x
 ```
 
 n+k patterns

--- a/TESTS.md
+++ b/TESTS.md
@@ -500,6 +500,12 @@ fun Rec { alpha = beta
   beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
 ```
 
+Symbol constructor, short
+
+```haskell
+fun ((:..?) {}) = undefined
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1218,12 +1224,6 @@ test
 ```
 
 ## Record syntax
-
-Symbol constructor, short
-
-```haskell
-fun ((:..?) {}) = undefined
-```
 
 Symbol constructor, long
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -413,6 +413,13 @@ data Person =
 
 ### Function declarations
 
+#### Pattern matchings
+
+n+k patterns
+
+```haskell
+f (n+5) = 0
+```
 
 ### Type family declarations
 
@@ -703,12 +710,6 @@ class A where
 ```
 
 ## Expressions
-
-n+k patterns
-
-``` haskell
-f (n+5) = 0
-```
 
 Binary symbol data constructor in pattern
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -420,6 +420,16 @@ Prefix notation for operators
 (+) a b = a
 ```
 
+Where clause
+
+```haskell
+sayHello = do
+  name <- getLine
+  putStrLn $ greeting name
+  where
+    greeting name = "Hello, " ++ name ++ "!"
+```
+
 #### Pattern matchings
 
 n+k patterns
@@ -1086,16 +1096,6 @@ g =
 ```
 
 ## Function declarations
-
-Where clause
-
-``` haskell
-sayHello = do
-  name <- getLine
-  putStrLn $ greeting name
-  where
-    greeting name = "Hello, " ++ name ++ "!"
-```
 
 Guards and pattern guards
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -519,6 +519,12 @@ fun (:..?) { alpha = beta
   beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
 ```
 
+Symbol field
+
+```haskell
+f (X {(..?) = x}) = x
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1237,12 +1243,6 @@ test
 ```
 
 ## Record syntax
-
-Symbol field
-
-```haskell
-f (X {(..?) = x}) = x
-```
 
 Punned symbol field
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -420,6 +420,19 @@ Prefix notation for operators
 (+) a b = a
 ```
 
+Guards and pattern guards
+
+```haskell
+f x
+  | x <- Just x
+  , x <- Just x =
+    case x of
+      Just x -> e
+  | otherwise = do e
+  where
+    x = y
+```
+
 Where clause
 
 ```haskell
@@ -1096,19 +1109,6 @@ g =
 ```
 
 ## Function declarations
-
-Guards and pattern guards
-
-``` haskell
-f x
-  | x <- Just x
-  , x <- Just x =
-    case x of
-      Just x -> e
-  | otherwise = do e
-  where
-    x = y
-```
 
 Multi-way if
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -421,6 +421,20 @@ n+k patterns
 f (n+5) = 0
 ```
 
+Binary symbol data constructor in pattern
+
+```haskell
+f (x :| _) = x
+
+f' ((:|) x _) = x
+
+f'' ((Data.List.NonEmpty.:|) x _) = x
+
+g (x:xs) = x
+
+g' ((:) x _) = x
+```
+
 ### Type family declarations
 
 Without annotations
@@ -710,20 +724,6 @@ class A where
 ```
 
 ## Expressions
-
-Binary symbol data constructor in pattern
-
-```haskell
-f (x :| _) = x
-
-f' ((:|) x _) = x
-
-f'' ((Data.List.NonEmpty.:|) x _) = x
-
-g (x:xs) = x
-
-g' ((:) x _) = x
-```
 
 Type application
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -506,6 +506,19 @@ Symbol constructor, short
 fun ((:..?) {}) = undefined
 ```
 
+Symbol constructor, long
+
+```haskell
+fun (:..?) { alpha = beta
+           , gamma = delta
+           , epsilon = zeta
+           , eta = theta
+           , iota = kappa
+           , lambda = mu
+           } =
+  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1224,19 +1237,6 @@ test
 ```
 
 ## Record syntax
-
-Symbol constructor, long
-
-```haskell
-fun (:..?) { alpha = beta
-           , gamma = delta
-           , epsilon = zeta
-           , eta = theta
-           , iota = kappa
-           , lambda = mu
-           } =
-  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
-```
 
 Symbol field
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -538,6 +538,13 @@ Punned symbol field
 f' (X {(..?)}) = (..?)
 ```
 
+`RecordWileCards`
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/274
+foo (Bar {..}) = Bar {..}
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1718,13 +1725,6 @@ neongreen "{" is lost when formatting "Foo{}" #366
 ```haskell
 -- https://github.com/chrisdone/hindent/issues/366
 foo = Nothing {}
-```
-
-ttuegel Record formatting applied to expressions with RecordWildCards #274
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/274
-foo (Bar {..}) = Bar {..}
 ```
 
 RecursiveDo `rec` and `mdo` keyword #328

--- a/TESTS.md
+++ b/TESTS.md
@@ -487,6 +487,19 @@ fun Rec {alpha = beta, gamma = delta, epsilon = zeta, eta = theta, iota = kappa}
   beta + delta + zeta + theta + kappa
 ```
 
+Long
+
+```haskell
+fun Rec { alpha = beta
+        , gamma = delta
+        , epsilon = zeta
+        , eta = theta
+        , iota = kappa
+        , lambda = mu
+        } =
+  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1205,19 +1218,6 @@ test
 ```
 
 ## Record syntax
-
-Pattern matching, long
-
-```haskell
-fun Rec { alpha = beta
-        , gamma = delta
-        , epsilon = zeta
-        , eta = theta
-        , iota = kappa
-        , lambda = mu
-        } =
-  beta + delta + zeta + theta + kappa + mu + beta + delta + zeta + theta + kappa
-```
 
 Symbol constructor, short
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -411,6 +411,9 @@ data Person =
   deriving (Eq, Show)
 ```
 
+### Function declarations
+
+
 ### Type family declarations
 
 Without annotations

--- a/TESTS.md
+++ b/TESTS.md
@@ -443,6 +443,19 @@ sayHello = do
     greeting name = "Hello, " ++ name ++ "!"
 ```
 
+Let inside a `where`
+
+```haskell
+g x =
+  let x = 1
+   in x
+  where
+    foo =
+      let y = 2
+          z = 3
+       in y
+```
+
 #### Pattern matchings
 
 n+k patterns
@@ -1120,19 +1133,6 @@ x =
          Just x -> e
          Nothing -> p
      | otherwise -> e
-```
-
-Let inside a `where`
-
-``` haskell
-g x =
-  let x = 1
-   in x
-  where
-    foo =
-      let y = 2
-          z = 3
-       in y
 ```
 
 Lists

--- a/TESTS.md
+++ b/TESTS.md
@@ -478,6 +478,15 @@ g (x:xs) = x
 g' ((:) x _) = x
 ```
 
+##### Pattern matchings against record
+
+Short
+
+```haskell
+fun Rec {alpha = beta, gamma = delta, epsilon = zeta, eta = theta, iota = kappa} = do
+  beta + delta + zeta + theta + kappa
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1196,13 +1205,6 @@ test
 ```
 
 ## Record syntax
-
-Pattern matching, short
-
-```haskell
-fun Rec {alpha = beta, gamma = delta, epsilon = zeta, eta = theta, iota = kappa} = do
-  beta + delta + zeta + theta + kappa
-```
 
 Pattern matching, long
 


### PR DESCRIPTION
This PR creates the "Function declarations" section and a few subsections, move tests related function declarations inside them, fixes issue URLs, and removes duplicated or unnecessary parts.

This is a part of #610.
