### PR TITLE
Remove the "Regression tests" section

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1092,6 +1092,7 @@ x = do
 Do as left-hand side of an infix operation
 
 ```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/238
 -- https://github.com/mihaimaruseac/hindent/issues/296
 block =
   do ds <- inBraces $ inWhiteSpace declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -573,6 +573,17 @@ f' (X {(..?)}) = (..?)
 foo (Bar {..}) = Bar {..}
 ```
 
+### Pragma declarations
+
+`INLINE`
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/255
+{-# INLINE f #-}
+f :: Int -> Int
+f n = n
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1590,15 +1601,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-sgraf812 top-level pragmas should not add an additional newline #255
-
-``` haskell
--- https://github.com/chrisdone/hindent/issues/255
-{-# INLINE f #-}
-f :: Int -> Int
-f n = n
-```
 
 ttuegel qualified infix sections get mangled #273
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1424,7 +1424,6 @@ g =
     _ -> False
 ```
 
-
 ## Comments
 
 Comments within a declaration

--- a/TESTS.md
+++ b/TESTS.md
@@ -1191,9 +1191,17 @@ for xs $ \case
   Left x -> x
 ```
 
+Qualified operator as an argument
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/273
+foo = foldr1 (V.++) [V.empty, V.empty]
+```
+
 Apply an infix operator in prefix style
 
 ```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/273
 ys = (++) [] []
 ```
 
@@ -1621,18 +1629,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-ttuegel qualified infix sections get mangled #273
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/273
-import qualified Data.Vector as V
-
-main :: IO ()
-main = do
-  let _ = foldr1 (V.++) [V.empty, V.empty]
-  pure ()
-```
 
 cdepillabout Long deriving clauses are not reformatted #289
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1191,6 +1191,13 @@ for xs $ \case
   Left x -> x
 ```
 
+Qualified operator
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/273
+xs = V.empty V.++ V.empty
+```
+
 In parentheses
 
 ```haskell
@@ -1621,8 +1628,6 @@ main = do
   pure ()
 
 -- more corner cases.
-xs = V.empty V.++ V.empty
-
 ys = (++) [] []
 ```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -458,6 +458,27 @@ newtype Foo =
            )
 ```
 
+Various deriving strategies
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/503
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Foo where
+
+import Data.Typeable
+import GHC.Generics
+
+newtype Number a =
+  Number a
+  deriving (Generic)
+  deriving newtype (Show, Eq)
+  deriving anyclass (Typeable)
+```
+
 ### Function declarations
 
 Prefix notation for operators
@@ -1647,27 +1668,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-paraseba Deriving strategies with multiple deriving clauses
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/503
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
-module Foo where
-
-import Data.Typeable
-import GHC.Generics
-
-newtype Number a =
-  Number a
-  deriving (Generic)
-  deriving newtype (Show, Eq)
-  deriving anyclass (Typeable)
-```
 
 neongreen "{" is lost when formatting "Foo{}" #366
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1407,7 +1407,26 @@ Type brackets
 foo :: $([t|Bool|]) -> a
 ```
 
-Quoted data constructors
+A quoted TH name from a normal data constructors
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/412
+data T =
+  (-)
+
+q = '(-)
+```
+
+A quoted TH name from a type name
+
+```haskell
+-- https://github.com/commercialhaskell/hindent/issues/412
+data (-)
+
+q = ''(-)
+```
+
+Quoted list constructors
 
 ```haskell
 cons = '(:)
@@ -1711,20 +1730,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-utdemir Hindent breaks TH name captures of operators #412
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/412
-data T =
-  (-)
-
-q = '(-)
-
-data (-)
-
-q = ''(-)
-```
 
 TimoFreiberg INLINE (and other) pragmas for operators are reformatted without parens #415
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -74,7 +74,7 @@ module X
     ) where
 ```
 
-## Imports
+## Imports, foreign imports, and foreign exports
 
 Import lists
 
@@ -153,6 +153,35 @@ import CommentAfter -- Comment here shouldn't affect newlines
 import CommentAfter
 ```
 
+### Foreign imports and exports
+
+Foreign export
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/479
+foreign export ccall "test" test :: IO ()
+```
+
+Foreign import without safety annotation
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/479
+foreign import ccall "test" test :: IO ()
+```
+
+Foreign import with a `safe` annotation
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/479
+foreign import ccall safe "test" test :: IO ()
+```
+
+Foreign import with an `unsafe` annotation
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/479
+foreign import ccall unsafe "test" test :: IO ()
+```
 ## Declarations
 
 Type family instances
@@ -1768,19 +1797,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-schroffl Hindent produces invalid Syntax from FFI exports #479
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/479
-foreign export ccall "test" test :: IO ()
-
-foreign import ccall "test" test :: IO ()
-
-foreign import ccall safe "test" test :: IO ()
-
-foreign import ccall unsafe "test" test :: IO ()
-```
 
 cdsmith Quotes are dropped from package imports #480
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1191,6 +1191,12 @@ for xs $ \case
   Left x -> x
 ```
 
+Apply an infix operator in prefix style
+
+```haskell
+ys = (++) [] []
+```
+
 Qualified operator
 
 ```haskell
@@ -1626,9 +1632,6 @@ main :: IO ()
 main = do
   let _ = foldr1 (V.++) [V.empty, V.empty]
   pure ()
-
--- more corner cases.
-ys = (++) [] []
 ```
 
 cdepillabout Long deriving clauses are not reformatted #289

--- a/TESTS.md
+++ b/TESTS.md
@@ -1565,13 +1565,22 @@ main = putStrLn "Hello, World!"
 {- This is another random comment. -}
 ```
 
-## Behaviour checks
+## Identifiers
 
 Unicode
 
 ```haskell
 α = γ * "ω"
 -- υ
+```
+
+`rec` and `mdo` are valid identifiers unless `RecursiveDo` is enabled
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/328
+rec = undefined
+
+mdo = undefined
 ```
 
 ## Complex input
@@ -1675,14 +1684,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-RecursiveDo `rec` and `mdo` keyword #328
-
-```haskell
-rec = undefined
-
-mdo = undefined
-```
 
 NorfairKing Do as left-hand side of an infix operation #296
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1591,19 +1591,6 @@ Escaped newlines
 
 ## Regression tests
 
-Wrapped import list shouldn't add newline
-
-```haskell given
-import ATooLongList
-       (alpha, beta, gamma, delta, epsilon, zeta, eta, theta)
-import B
-```
-
-```haskell expect
-import ATooLongList (alpha, beta, delta, epsilon, eta, gamma, theta, zeta)
-import B
-```
-
 sgraf812 top-level pragmas should not add an additional newline #255
 
 ``` haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -1433,7 +1433,7 @@ Unicode
 
 A complex, slow-to-print decl
 
-``` haskell
+```haskell
 quasiQuotes =
   [ ( ''[]
     , \(typeVariable:_) _automaticPrinter ->
@@ -1472,7 +1472,7 @@ quasiQuotes =
 
 Random snippet from hindent itself
 
-``` haskell
+```haskell
 exp' (App _ op a) = do
   (fits, st) <- fitsOnOneLine (spaced (map pretty (f : args)))
   if fits

--- a/TESTS.md
+++ b/TESTS.md
@@ -1044,6 +1044,16 @@ x = do
   mapM_ (putStrLn . Fixme.formatTodo) (concatMap Fixme.getTodos comments)
 ```
 
+Do as left-hand side of an infix operation
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/296
+block =
+  do ds <- inBraces $ inWhiteSpace declarations
+     return $ Block ds
+     <?> "block"
+```
+
 ### Function applications
 
 Long line, tuple
@@ -1684,16 +1694,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-NorfairKing Do as left-hand side of an infix operation #296
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/296
-block =
-  do ds <- inBraces $ inWhiteSpace declarations
-     return $ Block ds
-     <?> "block"
-```
 
 NorfairKing Hindent linebreaks after very short names if the total line length goes over 80 #405
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1558,16 +1558,6 @@ Escaped newlines
 
 ## Regression tests
 
-cocreature removed from declaration issue #186
-
-``` haskell
--- https://github.com/chrisdone/hindent/issues/186
-trans One e n =
-  M.singleton
-    (Query Unmarked (Mark NonExistent)) -- The goal of this is to fail always
-    (emptyImage {notPresent = S.singleton (TransitionResult Two (Just A) n)})
-```
-
 tfausak support shebangs #208
 
 ``` haskell given

--- a/TESTS.md
+++ b/TESTS.md
@@ -1808,23 +1808,6 @@ Escaped newlines
 
 ## Regression tests
 
-sophie-h Fails to create required indentation for infix #238
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/238
-{-# LANGUAGE ScopedTypeVariables #-}
-
-import Control.Exception
-
-x :: IO Int
-x =
-  do putStrLn "ok"
-     error "ok"
-     `catch` (\(_ :: IOException) -> pure 1) `catch`
-  (\(_ :: ErrorCall) -> pure 2)
-
-```
-
 lippirk Comments on functions in where clause not quite right #540
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -699,6 +699,17 @@ Multiple
 fun :: (Class a, Class b) => a -> b -> c
 ```
 
+Long constraints
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/222
+foo ::
+     ( Foooooooooooooooooooooooooooooooooooooooooo
+     , Foooooooooooooooooooooooooooooooooooooooooo
+     )
+  => A
+```
+
 Class constraints should leave `::` on same line
 
 ```haskell
@@ -1546,23 +1557,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-meditans hindent freezes when trying to format this code #222
-
-``` haskell
-c :: forall new.
-     ( Settable "pitch" Pitch (Map.AsMap (new Map.:\ "pitch")) new
-     , Default (Book' (Map.AsMap (new Map.:\ "pitch")))
-     )
-  => Book' new
-c = set #pitch C (def :: Book' (Map.AsMap (new Map.:\ "pitch")))
-
-foo ::
-     ( Foooooooooooooooooooooooooooooooooooooooooo
-     , Foooooooooooooooooooooooooooooooooooooooooo
-     )
-  => A
-```
 
 bitemyapp wonky multiline comment handling #231
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -552,6 +552,13 @@ g (x:xs) = x
 g' ((:) x _) = x
 ```
 
+Infix constructor pattern
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/424
+from $ \(author `InnerJoin` post) -> pure ()
+```
+
 ##### Pattern matchings against record
 
 Short
@@ -1737,13 +1744,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-NorfairKing Infix constructor pattern is broken #424
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/424
-from $ \(author `InnerJoin` post) -> pure ()
-```
 
 michalrus `let ... in ...` inside of `do` breaks compilation #467
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1291,6 +1291,13 @@ test = (:@)
 
 ### Records
 
+No field
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/366
+foo = Nothing {}
+```
+
 Short
 
 ```haskell
@@ -1668,13 +1675,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-neongreen "{" is lost when formatting "Foo{}" #366
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/366
-foo = Nothing {}
-```
 
 RecursiveDo `rec` and `mdo` keyword #328
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1256,7 +1256,7 @@ g =
 
 Comments within a declaration
 
-``` haskell
+```haskell
 bob -- after bob
  =
   foo -- next to foo
@@ -1328,7 +1328,7 @@ gamma = do
 
 Haddock comments
 
-``` haskell
+```haskell
 -- | Module comment.
 module X where
 
@@ -1357,7 +1357,7 @@ data X =
 
 Comments around regular declarations
 
-``` haskell
+```haskell
 -- This is some random comment.
 -- | Main entry point.
 main = putStrLn "Hello, World!"
@@ -1366,7 +1366,7 @@ main = putStrLn "Hello, World!"
 
 Multi-line comments
 
-``` haskell
+```haskell
 bob {- after bob -}
  =
   foo {- next to foo -}
@@ -1411,7 +1411,7 @@ foo = 1 {- after foo -}
 
 Multi-line comments with multi-line contents
 
-``` haskell
+```haskell
 {- | This is some random comment.
 Here is more docs and such.
 Etc.

--- a/TESTS.md
+++ b/TESTS.md
@@ -1558,20 +1558,6 @@ Escaped newlines
 
 ## Regression tests
 
-bitemyapp wonky multiline comment handling #231
-
-``` haskell
-module Woo where
-
-hi = "hello"
-{-
-test comment
--}
--- blah blah
--- blah blah
--- blah blah
-```
-
 cocreature removed from declaration issue #186
 
 ``` haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -973,14 +973,6 @@ Type application
 fun @Int 12
 ```
 
-Let binding with implicit parameters
-
-```haskell
-f =
-  let ?x = 42
-   in f
-```
-
 ### Case expressions
 
 Normal case
@@ -1151,6 +1143,26 @@ foo =
   alloca 10 $ \a ->
     alloca 20 $ \b ->
       cFunction fooo barrr muuu (fooo barrr muuu) (fooo barrr muuu)
+```
+
+### Let ... in expressions
+
+With implicit parameters
+
+```haskell
+f =
+  let ?x = 42
+   in f
+```
+
+inside a `do`
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/467
+main :: IO ()
+main = do
+  let x = 5
+   in when (x > 0) (return ())
 ```
 
 ### List comprehensions
@@ -1744,16 +1756,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-michalrus `let ... in ...` inside of `do` breaks compilation #467
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/467
-main :: IO ()
-main = do
-  let x = 5
-   in when (x > 0) (return ())
-```
 
 sophie-h Breaking valid top-level template haskell #473
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -138,6 +138,21 @@ import Name hiding ()
 import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 ```
 
+Preserve newlines between import groups
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/200
+import GHC.Monad
+
+import CommentAfter -- Comment here shouldn't affect newlines
+import HelloWorld
+
+import CommentAfter -- Comment here shouldn't affect newlines
+
+-- Comment here shouldn't affect newlines
+import CommentAfter
+```
+
 ## Declarations
 
 Type family instances
@@ -1575,34 +1590,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-joe9 preserve newlines between import groups
-
-``` haskell
--- https://github.com/chrisdone/hindent/issues/200
-import Data.List
-import Data.Maybe
-
-import FooBar
-import MyProject
-
-import GHC.Monad
-
--- blah
-import Hello
-
-import CommentAfter -- Comment here shouldn't affect newlines
-import HelloWorld
-
-import CommentAfter -- Comment here shouldn't affect newlines
-
-import HelloWorld
-
--- Comment here shouldn't affect newlines
-import CommentAfter
-
-import HelloWorld
-```
 
 Wrapped import list shouldn't add newline
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -13,6 +13,7 @@ No newlines after a shebang
 
 ```haskell given
 #!/usr/bin/env stack
+
 -- stack runghc
 main =
  pure ()

--- a/TESTS.md
+++ b/TESTS.md
@@ -623,6 +623,13 @@ f :: Int -> Int
 f n = n
 ```
 
+`NOINLINE` with an operator enclosed by parentheses
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/415
+{-# NOINLINE (<>) #-}
+```
+
 ### Type family declarations
 
 Without annotations
@@ -1730,13 +1737,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-TimoFreiberg INLINE (and other) pragmas for operators are reformatted without parens #415
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/415
-{-# NOINLINE (<>) #-}
-```
 
 NorfairKing Infix constructor pattern is broken #424
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1420,7 +1420,7 @@ q = '(-)
 A quoted TH name from a type name
 
 ```haskell
--- https://github.com/commercialhaskell/hindent/issues/412
+-- https://github.com/mihaimaruseac/hindent/issues/412
 data (-)
 
 q = ''(-)

--- a/TESTS.md
+++ b/TESTS.md
@@ -920,9 +920,9 @@ Empty lambda case
 f2 = \case {}
 ```
 
-### Function applications
+### `do` expressions
 
-Long line, inside a `do`
+Long function applications
 
 ```haskell
 test = do
@@ -935,6 +935,22 @@ test = do
     nuXiOmicron
     piRhoS81
 ```
+
+Large bindings
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/221
+x = do
+  config <- execParser options
+  comments <-
+    case config of
+      Diff False args -> commentsFromDiff args
+      Diff True args -> commentsFromDiff ("--cached" : args)
+      Files args -> commentsFromFiles args
+  mapM_ (putStrLn . Fixme.formatTodo) (concatMap Fixme.getTodos comments)
+```
+
+### Function applications
 
 Long line, tuple
 
@@ -1530,19 +1546,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-jml Adds trailing whitespace when wrapping #221
-
-```haskell
-x = do
-  config <- execParser options
-  comments <-
-    case config of
-      Diff False args -> commentsFromDiff args
-      Diff True args -> commentsFromDiff ("--cached" : args)
-      Files args -> commentsFromFiles args
-  mapM_ (putStrLn . Fixme.formatTodo) (concatMap Fixme.getTodos comments)
-```
 
 meditans hindent freezes when trying to format this code #222
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -9,6 +9,23 @@ like, or contribute additional sections to it, or regression tests.
 
 ## Shebangs
 
+No newlines after a shebang
+
+```haskell given
+#!/usr/bin/env stack
+-- stack runghc
+main =
+ pure ()
+-- https://github.com/chrisdone/hindent/issues/208
+```
+
+```haskell expect
+#!/usr/bin/env stack
+-- stack runghc
+main = pure ()
+-- https://github.com/chrisdone/hindent/issues/208
+```
+
 Double shebangs
 
 ```haskell
@@ -1557,23 +1574,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-tfausak support shebangs #208
-
-``` haskell given
-#!/usr/bin/env stack
--- stack runghc
-main =
- pure ()
--- https://github.com/chrisdone/hindent/issues/208
-```
-
-``` haskell expect
-#!/usr/bin/env stack
--- stack runghc
-main = pure ()
--- https://github.com/chrisdone/hindent/issues/208
-```
 
 joe9 preserve newlines between import groups
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -153,6 +153,15 @@ import CommentAfter -- Comment here shouldn't affect newlines
 import CommentAfter
 ```
 
+`PackageImports`
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/480
+{-# LANGUAGE PackageImports #-}
+
+import qualified "base" Prelude as P
+```
+
 ### Foreign imports and exports
 
 Foreign export
@@ -1798,15 +1807,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-cdsmith Quotes are dropped from package imports #480
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/480
-{-# LANGUAGE PackageImports #-}
-
-import qualified "base" Prelude as P
-```
 
 sophie-h Fails to create required indentation for infix #238
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -440,6 +440,24 @@ data Person =
   deriving (Eq, Show)
 ```
 
+Multiple derivings
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/289
+newtype Foo =
+  Foo Proxy
+  deriving ( Functor
+           , Applicative
+           , Monad
+           , Semigroup
+           , Monoid
+           , Alternative
+           , MonadPlus
+           , Foldable
+           , Traversable
+           )
+```
+
 ### Function declarations
 
 Prefix notation for operators
@@ -1629,23 +1647,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-cdepillabout Long deriving clauses are not reformatted #289
-
-```haskell
-newtype Foo =
-  Foo Proxy
-  deriving ( Functor
-           , Applicative
-           , Monad
-           , Semigroup
-           , Monoid
-           , Alternative
-           , MonadPlus
-           , Foldable
-           , Traversable
-           )
-```
 
 paraseba Deriving strategies with multiple deriving clauses
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -688,7 +688,7 @@ f' :: (:?:) a b
 Single
 
 ```haskell
--- https://github.com/commercialhaskell/hindent/issues/244
+-- https://github.com/mihaimaruseac/hindent/issues/244
 x :: Num a => a
 x = undefined
 ```

--- a/TESTS.md
+++ b/TESTS.md
@@ -1197,6 +1197,13 @@ In parentheses
 cat = (++)
 ```
 
+Qualified operator in parentheses
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/273
+cons = (V.++)
+```
+
 The first character of an infix operator can be `@` unless `TypeApplications` is enabled.
 
 ```haskell
@@ -1617,9 +1624,6 @@ main = do
 xs = V.empty V.++ V.empty
 
 ys = (++) [] []
-
-cons :: V.Vector a -> V.Vector a -> V.Vector a
-cons = (V.++)
 ```
 
 cdepillabout Long deriving clauses are not reformatted #289

--- a/TESTS.md
+++ b/TESTS.md
@@ -182,6 +182,7 @@ Foreign import with an `unsafe` annotation
 -- https://github.com/mihaimaruseac/hindent/issues/479
 foreign import ccall unsafe "test" test :: IO ()
 ```
+
 ## Declarations
 
 Type family instances

--- a/TESTS.md
+++ b/TESTS.md
@@ -17,14 +17,14 @@ No newlines after a shebang
 -- stack runghc
 main =
  pure ()
--- https://github.com/chrisdone/hindent/issues/208
+-- https://github.com/mihaimaruseac/hindent/issues/208
 ```
 
 ```haskell expect
 #!/usr/bin/env stack
 -- stack runghc
 main = pure ()
--- https://github.com/chrisdone/hindent/issues/208
+-- https://github.com/mihaimaruseac/hindent/issues/208
 ```
 
 Double shebangs

--- a/TESTS.md
+++ b/TESTS.md
@@ -1689,6 +1689,25 @@ main = putStrLn "Hello, World!"
 {- This is another random comment. -}
 ```
 
+Comments on functions in where clause
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/540
+topLevelFunc1 = f
+  where
+    -- comment on func in where clause
+    -- stays in the where clause
+    f = undefined
+
+topLevelFunc2 = f . g
+  where
+    {- multi
+       line
+       comment -}
+    f = undefined
+    -- single line comment
+    g = undefined
+```
 ## Identifiers
 
 Unicode
@@ -1805,26 +1824,4 @@ Escaped newlines
     }
 #define SHORT_MACRO_DEFINITION \
   x
-```
-
-## Regression tests
-
-lippirk Comments on functions in where clause not quite right #540
-
-```haskell
--- https://github.com/chrisdone/hindent/issues/540
-topLevelFunc1 = f
-  where
-    -- comment on func in where clause
-    -- stays in the where clause
-    f = undefined
-
-topLevelFunc2 = f . g
-  where
-    {- multi
-       line
-       comment -}
-    f = undefined
-    -- single line comment
-    g = undefined
 ```

--- a/TESTS.md
+++ b/TESTS.md
@@ -1424,7 +1424,7 @@ main = putStrLn "Hello, World!"
 
 Unicode
 
-``` haskell
+```haskell
 α = γ * "ω"
 -- υ
 ```

--- a/TESTS.md
+++ b/TESTS.md
@@ -1087,6 +1087,24 @@ test
   ,)
 ```
 
+Linebreaks after very short names if the total line length goes over 80
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/405
+t =
+  f "this is a very loooooooooooooooooooooooooooong string that goes over the line length"
+    argx
+    argy
+    argz
+
+t =
+  function
+    "this is a very loooooooooooooooooooooooooooong string that goes over the line length"
+    argx
+    argy
+    argz
+```
+
 ### Lambda expressions
 
 Lazy patterns
@@ -1694,24 +1712,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-NorfairKing Hindent linebreaks after very short names if the total line length goes over 80 #405
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/405
-t =
-  f "this is a very loooooooooooooooooooooooooooong string that goes over the line length"
-    argx
-    argy
-    argz
-
-t =
-  function
-    "this is a very loooooooooooooooooooooooooooong string that goes over the line length"
-    argx
-    argy
-    argz
-```
 
 utdemir Hindent breaks TH name captures of operators #412
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1343,6 +1343,18 @@ data T a =
 test = (:@)
 ```
 
+Force indent and print RHS in a top-level expression
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/473
+template $
+  haskell
+    [ SomeVeryLongName
+    , AnotherLongNameEvenLongToBreakTheLine
+    , LastLongNameInList
+    ]
+```
+
 ### Records
 
 No field
@@ -1756,18 +1768,6 @@ Escaped newlines
 ```
 
 ## Regression tests
-
-sophie-h Breaking valid top-level template haskell #473
-
-```haskell
--- https://github.com/commercialhaskell/hindent/issues/473
-template $
-  haskell
-    [ ''SomeVeryLongName
-    , ''AnotherLongNameEvenLongToBreakTheLine
-    , ''LastLongNameInList
-    ]
-```
 
 schroffl Hindent produces invalid Syntax from FFI exports #479
 


### PR DESCRIPTION
This PR splits large tests, removes duplicated tests, and moves tests in the 'Regression tests" section to proper sections.

Fixes: #610.
