### PR TITLE
Print unboxed sum type signatures correctly

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1638,14 +1638,6 @@ foo = undefined
     go = undefined
 ```
 
-`UnboxedSums`
-
-```haskell
-{-# LANGUAGE UnboxedSums #-}
-
-f :: (# (# Int, String #) | String #) -> (# Int | String #)
-```
-
 #### Promoted types
 
 Promoted lists
@@ -1759,6 +1751,32 @@ Symbol class constructor in class constraint
 ```haskell
 f :: (a :?: b) => (a, b)
 f' :: ((:?:) a b) => (a, b)
+```
+
+#### `UnboxedSums`
+
+Short
+
+```haskell
+{-# LANGUAGE UnboxedSums #-}
+
+f :: (# (# Int, String #) | String #) -> (# Int | String #)
+```
+
+Long
+
+```haskell
+{-# LANGUAGE UnboxedSums #-}
+
+f' ::
+     (# (# Int, String #)
+      | Either Bool Int
+      | Either Bool Int
+      | Either Bool Int
+      | Either Bool Int
+      | Either Bool Int
+      | String #)
+  -> (# Int | String #)
 ```
 
 ### Type synonym declarations

--- a/TESTS.md
+++ b/TESTS.md
@@ -1643,7 +1643,7 @@ foo = undefined
 ```haskell
 {-# LANGUAGE UnboxedSums #-}
 
-f :: (# Int | Bool | String #)
+f :: (# (# Int, String #) | String #) -> (# Int | String #)
 ```
 
 #### Promoted types

--- a/TESTS.md
+++ b/TESTS.md
@@ -1753,9 +1753,9 @@ f :: (a :?: b) => (a, b)
 f' :: ((:?:) a b) => (a, b)
 ```
 
-#### `UnboxedSums`
+#### Unboxed types
 
-Short
+Short unboxed sums
 
 ```haskell
 {-# LANGUAGE UnboxedSums #-}
@@ -1763,7 +1763,7 @@ Short
 f :: (# (# Int, String #) | String #) -> (# Int | String #)
 ```
 
-Long
+Long unboxed sums
 
 ```haskell
 {-# LANGUAGE UnboxedSums #-}
@@ -1777,6 +1777,16 @@ f' ::
       | Either Bool Int
       | String #)
   -> (# Int | String #)
+```
+
+Large unboxed tuples
+
+```haskell
+{-# LANGUAGE UnboxedTuples #-}
+
+f :: (# Looooooooooooooooooooooooooooooooooooooooooooong
+      , Looooooooooooooooooooooooooooooooooooooooooooong
+      , Looooooooooooooooooooooooooooooooooooooooooooong #)
 ```
 
 ### Type synonym declarations

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1024,7 +1024,7 @@ prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple []) = string "()"
 prettyHsType (HsTupleTy _ HsUnboxedTuple xs) = hUnboxedTuple $ fmap pretty xs
 prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple xs) =
   hvTuple' $ fmap pretty xs
-prettyHsType (HsSumTy _ xs) = unboxedParens $ hBarSep $ fmap pretty xs
+prettyHsType (HsSumTy _ xs) = hvUnboxedSum' $ fmap pretty xs
   -- For `HsOpTy`, we do not need a single quote for the infix operator. An
   -- explicit promotion is necessary if there is a data constructor and
   -- a type with the same name. However, infix data constructors never

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1021,7 +1021,7 @@ prettyHsType (HsFunTy _ _ a b) = (pretty a >> string " -> ") |=> pretty b
 prettyHsType (HsListTy _ xs) = brackets $ pretty xs
 prettyHsType (HsTupleTy _ HsUnboxedTuple []) = string "(# #)"
 prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple []) = string "()"
-prettyHsType (HsTupleTy _ HsUnboxedTuple xs) = hUnboxedTuple $ fmap pretty xs
+prettyHsType (HsTupleTy _ HsUnboxedTuple xs) = hvUnboxedTuple' $ fmap pretty xs
 prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple xs) =
   hvTuple' $ fmap pretty xs
 prettyHsType (HsSumTy _ xs) = hvUnboxedSum' $ fmap pretty xs

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1019,8 +1019,11 @@ prettyHsType (HsAppTy _ l r) = spaced $ fmap pretty [l, r]
 prettyHsType (HsAppKindTy _ l r) = pretty l >> string " @" >> pretty r
 prettyHsType (HsFunTy _ _ a b) = (pretty a >> string " -> ") |=> pretty b
 prettyHsType (HsListTy _ xs) = brackets $ pretty xs
-prettyHsType (HsTupleTy _ _ []) = string "()"
-prettyHsType (HsTupleTy _ _ xs) = hvTuple' $ fmap pretty xs
+prettyHsType (HsTupleTy _ HsUnboxedTuple []) = string "(# #)"
+prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple []) = string "()"
+prettyHsType (HsTupleTy _ HsUnboxedTuple xs) = hUnboxedTuple $ fmap pretty xs
+prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple xs) =
+  hvTuple' $ fmap pretty xs
 prettyHsType (HsSumTy _ xs) = unboxedSums $ hBarSep $ fmap pretty xs
   -- For `HsOpTy`, we do not need a single quote for the infix operator. An
   -- explicit promotion is necessary if there is a data constructor and

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -520,7 +520,7 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
     isMissing Missing {} = True
     isMissing _ = False
 prettyHsExpr (ExplicitSum _ _ _ expr) =
-  unboxedSums $ spaced [string "|", pretty expr]
+  unboxedParens $ spaced [string "|", pretty expr]
 prettyHsExpr (HsCase _ cond arms) = do
   string "case " |=> do
     pretty cond
@@ -1024,7 +1024,7 @@ prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple []) = string "()"
 prettyHsType (HsTupleTy _ HsUnboxedTuple xs) = hUnboxedTuple $ fmap pretty xs
 prettyHsType (HsTupleTy _ HsBoxedOrConstraintTuple xs) =
   hvTuple' $ fmap pretty xs
-prettyHsType (HsSumTy _ xs) = unboxedSums $ hBarSep $ fmap pretty xs
+prettyHsType (HsSumTy _ xs) = unboxedParens $ hBarSep $ fmap pretty xs
   -- For `HsOpTy`, we do not need a single quote for the infix operator. An
   -- explicit promotion is necessary if there is a data constructor and
   -- a type with the same name. However, infix data constructors never

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -7,6 +7,7 @@ module HIndent.Pretty.Combinators.Lineup
   , vTuple
   , vTuple'
   , hPromotedTuple
+  , hUnboxedTuple
   , -- * Records
     hvFields
   , hFields
@@ -68,6 +69,10 @@ vTuple' = vLineup' ("(", ")")
 -- | Runs printers to construct a promoted tuple in a line.
 hPromotedTuple :: [Printer ()] -> Printer ()
 hPromotedTuple = promotedTupleParens . hCommaSep
+
+-- | RUns printers to construct an unboxed tuple in a line.
+hUnboxedTuple :: [Printer ()] -> Printer ()
+hUnboxedTuple = unboxedSums . hCommaSep
 
 -- | Applies 'hFields' if the result fits in a line or 'vFields' otherwise.
 hvFields :: [Printer ()] -> Printer ()

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -8,6 +8,8 @@ module HIndent.Pretty.Combinators.Lineup
   , vTuple'
   , hPromotedTuple
   , hUnboxedTuple
+  , -- * Unboxed sums
+    hvUnboxedSum'
   , -- * Records
     hvFields
   , hFields
@@ -70,9 +72,29 @@ vTuple' = vCommaSepWrapped' ("(", ")")
 hPromotedTuple :: [Printer ()] -> Printer ()
 hPromotedTuple = promotedTupleParens . hCommaSep
 
--- | RUns printers to construct an unboxed tuple in a line.
+-- | Runs printers to construct an unboxed tuple in a line.
 hUnboxedTuple :: [Printer ()] -> Printer ()
 hUnboxedTuple = unboxedParens . hCommaSep
+
+-- | Runs printers to construct an unboxed sum. The elements are aligned
+-- either in a line or vertically.
+--
+-- The enclosing parenthesis will be printed on the same line as the last
+-- element.
+hvUnboxedSum' :: [Printer ()] -> Printer ()
+hvUnboxedSum' = (<-|>) <$> hUnboxedSum <*> vUnboxedSum'
+
+-- | Runs printers to construct an unboxed sum in a line.
+hUnboxedSum :: [Printer ()] -> Printer ()
+hUnboxedSum = unboxedParens . hBarSep
+
+-- | Runs printers to construct an unboxed sum where the elements are
+-- aligned vertically.
+--
+-- The enclosing parenthesis will be printed on the same line as the last
+-- element.
+vUnboxedSum' :: [Printer ()] -> Printer ()
+vUnboxedSum' = vWrappedLineup' '|' ("(#", " #)")
 
 -- | Applies 'hFields' if the result fits in a line or 'vFields' otherwise.
 hvFields :: [Printer ()] -> Printer ()

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -59,12 +59,12 @@ hTuple = parens . hCommaSep
 -- | Runs printers to construct a tuple where elements are aligned
 -- vertically.
 vTuple :: [Printer ()] -> Printer ()
-vTuple = vLineup ("(", ")")
+vTuple = vCommaSepWrapped ("(", ")")
 
 -- | Similar to 'vTuple', but the closing parenthesis is in the last
 -- element.
 vTuple' :: [Printer ()] -> Printer ()
-vTuple' = vLineup' ("(", ")")
+vTuple' = vCommaSepWrapped' ("(", ")")
 
 -- | Runs printers to construct a promoted tuple in a line.
 hPromotedTuple :: [Printer ()] -> Printer ()
@@ -85,12 +85,12 @@ hFields = braces . hCommaSep
 -- | Runs printers to construct a record where elements are aligned
 -- vertically.
 vFields :: [Printer ()] -> Printer ()
-vFields = vLineup ("{", "}")
+vFields = vCommaSepWrapped ("{", "}")
 
 -- | Similar to 'vFields', but the closing brace is in the same line as the
 -- last element.
 vFields' :: [Printer ()] -> Printer ()
-vFields' = vLineup' ("{", "}")
+vFields' = vCommaSepWrapped' ("{", "}")
 
 -- | Runs printers to construct a list in a line.
 hList :: [Printer ()] -> Printer ()
@@ -99,29 +99,11 @@ hList = brackets . hCommaSep
 -- | Runs printers to construct a list where elements are aligned
 -- vertically.
 vList :: [Printer ()] -> Printer ()
-vList = vLineup ("[", "]")
+vList = vCommaSepWrapped ("[", "]")
 
 -- | Runs printers to construct a promoted list in a line.
 hPromotedList :: [Printer ()] -> Printer ()
 hPromotedList = promotedListBrackets . hCommaSep
-
--- | Prints elements in vertical with the given prefix and suffix.
-vLineup :: (String, String) -> [Printer ()] -> Printer ()
-vLineup (prefix, suffix) ps =
-  string prefix >>
-  space |=> do
-    vCommaSep ps
-    newline
-    indentedWithSpace (-(fromIntegral (length prefix) + 1)) $ string suffix
-
--- | Similar to 'vLineup' but the suffix is in the same line as the last
--- element.
-vLineup' :: (String, String) -> [Printer ()] -> Printer ()
-vLineup' (prefix, suffix) ps =
-  string prefix >>
-  space |=> do
-    vCommaSep ps
-    string suffix
 
 -- | Runs printers in a line with a space as the separator.
 spaced :: [Printer ()] -> Printer ()
@@ -162,6 +144,16 @@ hCommaSep = inter (string ", ")
 vCommaSep :: [Printer ()] -> Printer ()
 vCommaSep = prefixedLined ", "
 
+-- | Prints elements separated by comma  in vertical with the given prefix
+-- and suffix.
+vCommaSepWrapped :: (String, String) -> [Printer ()] -> Printer ()
+vCommaSepWrapped = vWrappedLineup ','
+
+-- | Similar to 'vCommaSepWrapped' but the suffix is in the same line as the last
+-- element.
+vCommaSepWrapped' :: (String, String) -> [Printer ()] -> Printer ()
+vCommaSepWrapped' = vWrappedLineup' ','
+
 -- | Runs printers with a dot as the separator.
 hDotSep :: [Printer ()] -> Printer ()
 hDotSep = inter (string ".")
@@ -182,6 +174,25 @@ prefixedLined pref (x:xs) = do
   forM_ xs $ \p -> do
     newline
     prefixed pref p
+
+-- | Prints elements in vertical with the given prefix, suffix, and
+-- separator.
+vWrappedLineup :: Char -> (String, String) -> [Printer ()] -> Printer ()
+vWrappedLineup sep (prefix, suffix) ps =
+  string prefix >>
+  space |=> do
+    prefixedLined [sep, ' '] ps
+    newline
+    indentedWithSpace (-(fromIntegral (length prefix) + 1)) $ string suffix
+
+-- | Similar to 'vWrappedLineup' but the suffix is in the same line as the
+-- last element.
+vWrappedLineup' :: Char -> (String, String) -> [Printer ()] -> Printer ()
+vWrappedLineup' sep (prefix, suffix) ps =
+  string prefix >>
+  space |=> do
+    prefixedLined [sep, ' '] ps
+    string suffix
 
 -- Inserts the first printer between each element of the list passed as the
 -- second argument and runs them.

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -7,7 +7,8 @@ module HIndent.Pretty.Combinators.Lineup
   , vTuple
   , vTuple'
   , hPromotedTuple
-  , hUnboxedTuple
+  , -- * Unboxed tuples
+    hvUnboxedTuple'
   , -- * Unboxed sums
     hvUnboxedSum'
   , -- * Records
@@ -72,9 +73,19 @@ vTuple' = vCommaSepWrapped' ("(", ")")
 hPromotedTuple :: [Printer ()] -> Printer ()
 hPromotedTuple = promotedTupleParens . hCommaSep
 
+-- | Runs printers to construct an unboxed tuple. The elements are aligned
+-- either in a line or vertically.
+hvUnboxedTuple' :: [Printer ()] -> Printer ()
+hvUnboxedTuple' = (<-|>) <$> hUnboxedTuple <*> vUnboxedTuple'
+
 -- | Runs printers to construct an unboxed tuple in a line.
 hUnboxedTuple :: [Printer ()] -> Printer ()
 hUnboxedTuple = unboxedParens . hCommaSep
+
+-- | Runs printers to construct an unboxed tuple where the elements are
+-- aligned vertically.
+vUnboxedTuple' :: [Printer ()] -> Printer ()
+vUnboxedTuple' = vCommaSepWrapped' ("(#", " #)")
 
 -- | Runs printers to construct an unboxed sum. The elements are aligned
 -- either in a line or vertically.

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -72,7 +72,7 @@ hPromotedTuple = promotedTupleParens . hCommaSep
 
 -- | RUns printers to construct an unboxed tuple in a line.
 hUnboxedTuple :: [Printer ()] -> Printer ()
-hUnboxedTuple = unboxedSums . hCommaSep
+hUnboxedTuple = unboxedParens . hCommaSep
 
 -- | Applies 'hFields' if the result fits in a line or 'vFields' otherwise.
 hvFields :: [Printer ()] -> Printer ()

--- a/src/HIndent/Pretty/Combinators/Wrap.hs
+++ b/src/HIndent/Pretty/Combinators/Wrap.hs
@@ -12,7 +12,7 @@ module HIndent.Pretty.Combinators.Wrap
   , wrapWithBars
   , promotedListBrackets
   , promotedTupleParens
-  , unboxedSums
+  , unboxedParens
   ) where
 
 import GHC.Types.Name
@@ -77,8 +77,8 @@ promotedTupleParens :: Printer a -> Printer a
 promotedTupleParens = wrap "'( " ")"
 
 -- | Wraps with @(# @ and @ #)@.
-unboxedSums :: Printer a -> Printer a
-unboxedSums = wrap "(# " " #)"
+unboxedParens :: Printer a -> Printer a
+unboxedParens = wrap "(# " " #)"
 
 -- | This function wraps the printer with the prefix and the suffix.
 wrap :: String -> String -> Printer a -> Printer a


### PR DESCRIPTION
This is a part of #638.
