### PR TITLE
Print unboxed expressions correctly

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1173,7 +1173,8 @@ Unboxed sum pattern matching.
 ```haskell
 {-# LANGUAGE UnboxedSums #-}
 
-f (# x | | | #) = undefined
+f (# (# n, _ #) | #) = (# n | #)
+f (# | b #) = (# | b #)
 ```
 
 Pattern matching against a infix constructor with a module name prefix

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -519,8 +519,14 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
       fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing Missing {} = True
     isMissing _ = False
-prettyHsExpr (ExplicitSum _ _ _ expr) =
-  unboxedParens $ spaced [string "|", pretty expr]
+prettyHsExpr (ExplicitSum _ position numElem expr) = do
+  string "(#"
+  forM_ [1 .. numElem] $ \idx -> do
+    if idx == position
+      then string " " >> pretty expr >> string " "
+      else string " "
+    when (idx < numElem) $ string "|"
+  string "#)"
 prettyHsExpr (HsCase _ cond arms) = do
   string "case " |=> do
     pretty cond
@@ -1258,7 +1264,8 @@ prettyPat (ParPat _ inner) = parens $ pretty inner
 #endif
 prettyPat (BangPat _ x) = string "!" >> pretty x
 prettyPat (ListPat _ xs) = hList $ fmap pretty xs
-prettyPat (TuplePat _ pats _) = hTuple $ fmap pretty pats
+prettyPat (TuplePat _ pats Boxed) = hTuple $ fmap pretty pats
+prettyPat (TuplePat _ pats Unboxed) = hUnboxedTuple $ fmap pretty pats
 prettyPat (SumPat _ x position numElem) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -1,7 +1,7 @@
 -- | Printer combinators for lining up multiple elements.
 module HIndent.Pretty.Combinators.Lineup
-    -- * Tuples
-  ( hvTuple
+  ( -- * Tuples
+    hvTuple
   , hvTuple'
   , hTuple
   , vTuple

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -1,7 +1,7 @@
 -- | Printer combinators for lining up multiple elements.
 module HIndent.Pretty.Combinators.Lineup
-  ( -- * Tuples
-    hvTuple
+    -- * Tuples
+  ( hvTuple
   , hvTuple'
   , hTuple
   , vTuple
@@ -9,6 +9,7 @@ module HIndent.Pretty.Combinators.Lineup
   , hPromotedTuple
   , -- * Unboxed tuples
     hvUnboxedTuple'
+  , hUnboxedTuple
   , -- * Unboxed sums
     hvUnboxedSum'
   , -- * Records


### PR DESCRIPTION
This is a part of #638.
