### PR TITLE
Reorganize the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fix formatting associated type families.
 - Fix formatting non-dependent record constructors.
 
-5.2.7:
-    * Fix -X option bug
+## [5.2.7] - 2019-03-16
+
+### Fixed
+
+- A bug in the `-X` option
 
 5.2.6:
     * Switch to optparse-applicative
@@ -192,6 +195,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.3.2]: https://github.com/mihaimaruseac/hindent/compare/5.3.1...v5.3.2
 [5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.3.0...5.3.1
 [5.3.0]: https://github.com/mihaimaruseac/hindent/compare/5.2.7...5.3.0
+[5.2.7]: https://github.com/mihaimaruseac/hindent/compare/5.2.6...5.2.7
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,9 +226,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Support for styles
 
-4.6.4
+## [4.6.4] - 2016-07-15
 
-	* Copy/delete file instead of renaming
+### Changed
+
+- The formatted file is now created by coping/deleting a file instead of renaming.
 
 4.4.6
 
@@ -272,6 +274,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.1.0]: https://github.com/mihaimaruseac/hindent/compare/5.0.1...5.1.0
 [5.0.1]: https://github.com/mihaimaruseac/hindent/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/mihaimaruseac/hindent/compare/4.6.4...5.0.0
+[4.6.4]: https://github.com/mihaimaruseac/hindent/compare/4.6.3...4.6.4
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Add parentheses around symbols `(:|)` when required.
 - Support `$p` pattern splices.
 - Fix formatting of associated type families.
-- Fix formatting non-dependent record constructors.
+- Fix formatting of non-dependent record constructors.
 
 ## [5.2.7] - 2019-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,8 +120,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 ### Added
 
 - HIndent now reports where a parse happened.
-- Support custom the `line-break` option.
-- Added `--line-breaks` parameter.
+- Added `--line-breaks` parameter to support custom line breaks.
 - Added the `RecStmt` support
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,11 +248,16 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Fixed a bug in infix patterns.
 
-4.4.2
+## [4.4.2] - 2015-04-05
 
-	* Bunch of Gibiansky style fixes.
-	* Support CPP.
-	* Tibell style fixes.
+### Added
+
+- Support for CPP.
+
+### Fixed
+
+- Bunch of Gibiansky style bugs.
+- Tibell style bugs.
 
 4.3.8
 
@@ -284,6 +289,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [4.6.4]: https://github.com/mihaimaruseac/hindent/compare/4.6.3...4.6.4
 [4.6.3]: https://github.com/mihaimaruseac/hindent/compare/4.6.2...4.6.3
 [4.4.5]: https://github.com/mihaimaruseac/hindent/compare/4.4.4...4.4.5
+[4.4.2]: https://github.com/mihaimaruseac/hindent/compare/4.4.1...4.4.2
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,11 +195,19 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Fixed pretty-printing explicit `forall`s in instances (Fixes [#218]).
 
-5.1.0:
+## [5.1.0] - 2016-08-25
 
-    * Rewrote comment association, more reliable
-    * Added --tab-size flag for indentation spaces
-    * Fixed some miscellaneous bugs
+### Added
+
+- `--tab-size` parameter for indentation spaces.
+
+### Changed
+
+- Rewrote comment association for more reliability.
+
+### Fixed
+
+- Some miscellaneous bugs.
 
 5.0.1:
 
@@ -254,6 +262,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.1]: https://github.com/mihaimaruseac/hindent/compare/5.2.0...5.2.1
 [5.2.0]: https://github.com/mihaimaruseac/hindent/compare/5.1.1...5.2.0
 [5.1.1]: https://github.com/mihaimaruseac/hindent/compare/5.1.0...5.1.1
+[5.1.0]: https://github.com/mihaimaruseac/hindent/compare/5.0.1...5.1.0
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.3.0...5.3.1
 [5.3.0]: https://github.com/mihaimaruseac/hindent/compare/5.2.7...5.3.0
 [5.2.7]: https://github.com/mihaimaruseac/hindent/compare/5.2.6...5.2.7
+[5.2.6]: https://github.com/mihaimaruseac/hindent/compare/5.2.5...5.2.6
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ## Fixed
 
-- Fixed pretty-printing infix data constructors.
+- Fixed pretty-printing for infix data constructors.
 - Fixed pretty-printing quasi-quoter names.
 - Fixed pretty-printing complicated type aliases.
 - Fixed pretty-printing complicated type signatures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,12 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Re-implement using [`bytestring`] instead of [`text`]
 
+## [5.0.0] - 2016-08-11
+
+### Removed
+
+- Support for styles
+
 5.0.0:
 
 	* Drop support for styles
@@ -269,6 +275,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.1.1]: https://github.com/mihaimaruseac/hindent/compare/5.1.0...5.1.1
 [5.1.0]: https://github.com/mihaimaruseac/hindent/compare/5.0.1...5.1.0
 [5.0.1]: https://github.com/mihaimaruseac/hindent/compare/5.0.0...5.0.1
+[5.0.0]: https://github.com/mihaimaruseac/hindent/compare/4.6.4...5.0.0
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fixed handling on large constraints.
 - Fixed pretty-printing multi-line comments.
 - Fixed bug resulting in adding a spurious space for comments at the end of a file.
-- Fixed adding a trailing white space on `<-`
+- Fixed bug which results in adding a trailing white space on `<-`
 
 ## [5.2.0] - 2016-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - `MonadFix` issues to support newer GHC versions.
 
+## [5.3.1] - 2019-06-28
+
+### Fixed
+
+- Comment relocations in where clauses of top-level function declarations.
+
 5.3.0:
     * Handle multiple deriving clauses in a DerivingStrategies scenario
     * Ignore non-files in findCabalFiles
@@ -179,6 +185,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.3.4]: https://github.com/mihaimaruseac/hindent/compare/v5.3.3...v5.3.4
 [5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
 [5.3.2]: https://github.com/mihaimaruseac/hindent/compare/5.3.1...v5.3.2
+[5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.3.0...v5.3.1
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,13 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Fixed the whole module printer.
 
+## [4.5.4] - 2015-06-22
+
+### Added
+
+- Improvements to Tibell style.
+- 6x speed up on rendering operators.
+
 ## [4.4.5] - 2015-11-10
 
 ### Fixed
@@ -265,11 +272,6 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - A bug in printing operators in statements.
 
-4.5.4
-
-	* Improvements to Tibell style.
-	* 6x speed up on rendering operators.
-
 [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD
 [5.3.4]: https://github.com/mihaimaruseac/hindent/compare/v5.3.3...v5.3.4
 [5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
@@ -290,6 +292,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.0.0]: https://github.com/mihaimaruseac/hindent/compare/4.6.4...5.0.0
 [4.6.4]: https://github.com/mihaimaruseac/hindent/compare/4.6.3...4.6.4
 [4.6.3]: https://github.com/mihaimaruseac/hindent/compare/4.6.2...4.6.3
+[4.5.4]: https://github.com/mihaimaruseac/hindent/compare/4.5.3...4.5.4
 [4.4.5]: https://github.com/mihaimaruseac/hindent/compare/4.4.4...4.4.5
 [4.4.2]: https://github.com/mihaimaruseac/hindent/compare/4.4.1...4.4.2
 [4.3.8]: https://github.com/mihaimaruseac/hindent/compare/4.3.7...4.3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,11 +139,16 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fixed pretty-printing complicated type aliases.
 - Fixed pretty-printing complicated type signatures.
 
-5.2.2:
+## [5.2.2] - 2017-01-16
 
-    * Parallel list comprehensions
-    * Leave do, lambda, lambda-case on previous line of $
-    * Misc fixes
+### Changed
+
+- HIndent now leaves do, lambda, and lambda-case on the previous line of `$`.
+
+### Fixed
+
+- Fixed pretty-printing parallel list comprehensions.
+- Miscellaneous fixes.
 
 5.2.1:
 
@@ -228,6 +233,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.5]: https://github.com/mihaimaruseac/hindent/compare/5.2.4...5.2.5
 [5.2.4]: https://github.com/mihaimaruseac/hindent/compare/5.2.3...5.2.4
 [5.2.3]: https://github.com/mihaimaruseac/hindent/compare/5.2.2...5.2.3
+[5.2.2]: https://github.com/mihaimaruseac/hindent/compare/5.2.1...5.2.2
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,15 +150,20 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fixed pretty-printing parallel list comprehensions.
 - Miscellaneous fixes.
 
-5.2.1:
+## [5.2.1] - 2016-09-01
 
-    * Fix hanging on large constraints
-    * Render multi-line comments
-    * Rename --tab-size to --indent-size
-    * Don't add a spurious space for comments at the end of the file
-    * Don't add trailing whitespace on <-
-    * Disable PatternSynonyms
-    * Put a newline before the closing bracket on a list
+### Changed
+
+- The `--tab-size` option is renamed to `--indent-size`.
+- The `PatternSynonyms` extension is now disabled-by-default.
+- HIndent now puts a newline before the closing bracket on a list.
+
+### Fixed
+
+- Fixed handling on large constraints.
+- Fixed pretty-printing multi-line comments.
+- Fixed adding a spurious space for comments at the end of a file.
+- Fixed adding a trailing white space on `<-`
 
 5.2.0:
 
@@ -234,6 +239,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.4]: https://github.com/mihaimaruseac/hindent/compare/5.2.3...5.2.4
 [5.2.3]: https://github.com/mihaimaruseac/hindent/compare/5.2.2...5.2.3
 [5.2.2]: https://github.com/mihaimaruseac/hindent/compare/5.2.1...5.2.2
+[5.2.1]: https://github.com/mihaimaruseac/hindent/compare/5.2.0...5.2.1
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Fixed
 
-- Fixed handling on large constraints.
+- Fixed handling of paragraph overhang when using large constraints.
 - Fixed pretty-printing multi-line comments.
 - Fixed bug resulting in adding a spurious space for comments at the end of a file.
 - Fixed bug which results in adding a trailing white space on `<-`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 ### Changed
 
 - The `--tab-size` option is renamed to `--indent-size`.
-- The `PatternSynonyms` extension is now disabled-by-default.
+- The `PatternSynonyms` extension is now disabled by default.
 - HIndent now puts a newline before the closing bracket on a list.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,13 +76,21 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Switched to [`optparse-applicative`].
 
-5.2.5:
+## [5.2.5] - 2018-01-04
 
-    * Support get extensions from `.cabal` file
-    * Improve indention with record constructions and updates
-    * Fix `let ... in` bug
-    * Fix top-level lambda expressions in TemplateHaskell slices
-    * Update to haskell-src-exts dependency to version `>= 1.20.0`
+### Added
+
+- Support getting extensions from a `.cabal` file
+
+### Changed
+
+- Improved the indentation with record constructions and updates
+- Updated [`haskell-src-exts`] dependency to version `>= 1.20.0`
+
+### Fixed
+
+- Fix the `let ... in` bug
+- Fix formatting top-level lambda expressions in `TemplateHaskell` slices
 
 5.2.4:
 
@@ -200,6 +208,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.3.0]: https://github.com/mihaimaruseac/hindent/compare/5.2.7...5.3.0
 [5.2.7]: https://github.com/mihaimaruseac/hindent/compare/5.2.6...5.2.7
 [5.2.6]: https://github.com/mihaimaruseac/hindent/compare/5.2.5...5.2.6
+[5.2.5]: https://github.com/mihaimaruseac/hindent/compare/5.2.4...5.2.5
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,17 +176,24 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 ### Changed
 
 - The default number of spaces for a tab is changed to 2.
-- The last parenthesis of an export list is now put on a new line.
 
-5.1.1:
+## [5.1.1] - 2016-08-29
 
-    * Preserve spaces between groups of imports (fixes #200)
-    * Support shebangs (closes #208)
-    * Output filename for parse errors (fixes #179)
-    * Input with newline ends with newline (closes #211)
-    * Document -X (closes #212)
-    * Fix explicit forall in instances (closes #218)
-    * Put last paren of export list on a new line #227
+### Added
+
+- Shebang support (Fixes [#208]).
+- Output the filename for parse errors (Fixes [#179]).
+- Added a document of the `-X` option (Fixes [#212]).
+
+### Changed
+
+- HIndent now preserves spaces between groups of imports (Fixes [#200]).
+- HIndent now preserves the last newline if the input ends with one (Fixes [#211]).
+- HIndent now puts the last parenthesis of an export list on a new line (Fixes [#227]).
+
+### Fixed
+
+- Fixed pretty-printing explicit `forall`s in instances (Fixes [#218]).
 
 5.1.0:
 
@@ -254,6 +261,13 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [#588]: https://github.com/mihaimaruseac/hindent/pull/588
 [#584]: https://github.com/mihaimaruseac/hindent/pull/584
 [#579]: https://github.com/mihaimaruseac/hindent/pull/579
+[#227]: https://github.com/mihaimaruseac/hindent/pull/227
+[#218]: https://github.com/mihaimaruseac/hindent/pull/218
+[#212]: https://github.com/mihaimaruseac/hindent/pull/212
+[#211]: https://github.com/mihaimaruseac/hindent/pull/211
+[#208]: https://github.com/mihaimaruseac/hindent/pull/208
+[#200]: https://github.com/mihaimaruseac/hindent/pull/200
+[#179]: https://github.com/mihaimaruseac/hindent/pull/179
 
 [`haskell-src-exts`]: https://hackage.haskell.org/package/haskell-src-exts
 [`ghc-lib-parser`]: https://hackage.haskell.org/package/ghc-lib-parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,4 +154,4 @@
 	* Improvements to Tibell style.
 	* 6x speed up on rendering operators.
 
-[unreleased]: [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD
+[unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,20 +44,25 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Comment relocations in where clauses of top-level function declarations.
 
-5.3.0:
-    * Handle multiple deriving clauses in a DerivingStrategies scenario
-    * Ignore non-files in findCabalFiles
-    * Allow batch processing of multiple files
-    * Prevent hindent from trying to open non-files when searching for
-      .cabal files
-    * Specify default extensions in configuration file
-    * Fix bad output for [p|Foo|] pattern quasi-quotes
-    * Parse C preprocessor line continuations
-    * Fix pretty printing of '(:)
-    * Add parens around symbols (:|) when required
-    * Support $p pattern splices
-    * Fix associated type families
-    * Non-dependent record constructor formatting
+## [5.3.0] - 2019-04-29
+
+### Added
+
+- Allow batch processing of multiple files.
+- You can now specify default extensions in the configuration file.
+
+### Fixed
+
+- Handle multiple deriving clauses in the `DerivingStrategies` scenario.
+- Ignore non-files in `findCabalFiles`.
+- Prevent HIndent from trying to open non-files when searching for `.cabal` files.
+- Fix the bad output for `[p|Foo|]` pattern quasi-quotes.
+- Fix pretty-printing of `'(:)`.
+- Fix parsing C preprocessor line continuations.
+- Add parentheses around symbols `(:|)` when required.
+- Support $p` pattern splices.
+- Fix formatting associated type families.
+- Fix formatting non-dependent record constructors.
 
 5.2.7:
     * Fix -X option bug
@@ -186,6 +191,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
 [5.3.2]: https://github.com/mihaimaruseac/hindent/compare/5.3.1...v5.3.2
 [5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.3.0...5.3.1
+[5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.2.7...5.3.0
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,11 +209,16 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Some miscellaneous bugs.
 
-5.0.1:
+## [5.0.1] - 2016-08-20
 
-    * Re-implement using bytestring instead of text
-    * Made compatible with GHC 7.8 through to GHC 8.0
-    * Added test suite and benchmarks in TESTS.md and BENCHMARKS.md
+### Added
+
+- Made compatible with GHC 7.8 through to GHC 8.0
+- Added test suites and benchmarks in [`TESTS.md`] and [`BENCHMARKS.md`]
+
+### Changed
+
+- Re-implement using [`bytestring`] instead of [`text`]
 
 5.0.0:
 
@@ -282,3 +287,8 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [`haskell-src-exts`]: https://hackage.haskell.org/package/haskell-src-exts
 [`ghc-lib-parser`]: https://hackage.haskell.org/package/ghc-lib-parser
 [`optparse-applicative`]: https://hackage.haskell.org/package/optparse-applicative
+[`bytestring`]: https://hackage.haskell.org/package/bytestring
+[`text`]: https://hackage.haskell.org/package/text
+
+[`TESTS.md`]: TESTS.md
+[`BENCHMARKS.md`]: BENCHMARKS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- The getConfig function is exported.
+
+### Changed
+
+- Switched the parser from
+  [`haskell-src-exts`](https://hackage.haskell.org/package/haskell-src-exts) to
+  [`ghc-lib-parser`](https://hackage.haskell.org/package/ghc-lib-parser-9.4.1.20220807).
+  This switch causes changes in the formatting results in some cases.
+
+### Removed
+
+- Test functions except `testAst`.
+
 5.3.0:
     * Handle multiple deriving clauses in a DerivingStrategies scenario
     * Ignore non-files in findCabalFiles
@@ -134,3 +153,5 @@
 
 	* Improvements to Tibell style.
 	* 6x speed up on rendering operators.
+
+[unreleased]: [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 ## Fixed
 
 - Fixed pretty-printing for infix data constructors.
-- Fixed pretty-printing quasi-quoter names.
+- Fixed pretty-printing of quasi-quoter names.
 - Fixed pretty-printing complicated type aliases.
 - Fixed pretty-printing complicated type signatures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@
 
 This version is accidentally pushlished, and is the same as 5.3.3.
 
+## [5.3.3] - 2022-07-07
+
+### Added
+
+- Support for GHC 9.2.2.
+- Test CI with GitHub Actions (WIP).
+
+### Fixed
+
+- Fixed a broken link to Servant by [@mattfbacon] in [#579].
+- Fixed a build with Cabal 3.6 by [@uhbif19] in [#584].
+- Fixed a compile error for GHC 9.2.2 by [@toku-sa-n] in [#588].
+
 5.3.0:
     * Handle multiple deriving clauses in a DerivingStrategies scenario
     * Ignore non-files in findCabalFiles
@@ -160,3 +173,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD
 [5.3.4]: https://github.com/mihaimaruseac/hindent/compare/v5.3.3...v5.3.4
+[5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
+
+[@mattfbacon]: https://github.com/mattfbacon
+[@uhbif19]: https://github.com/uhbif19
+
+[#588]: https://github.com/mihaimaruseac/hindent/pull/588
+[#584]: https://github.com/mihaimaruseac/hindent/pull/584
+[#579]: https://github.com/mihaimaruseac/hindent/pull/579

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Fixed pretty-printing for infix data constructors.
 - Fixed pretty-printing of quasi-quoter names.
-- Fixed pretty-printing complicated type aliases.
+- Fixed pretty-printing of complicated type aliases.
 - Fixed pretty-printing complicated type signatures.
 
 ## [5.2.2] - 2017-01-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
 [5.3.2]: https://github.com/mihaimaruseac/hindent/compare/5.3.1...v5.3.2
 [5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.3.0...5.3.1
-[5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.2.7...5.3.0
+[5.3.0]: https://github.com/mihaimaruseac/hindent/compare/5.2.7...5.3.0
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Fixed
 
-- Fixed pretty-printing parallel list comprehensions.
+- Fixed pretty-printing of parallel list comprehensions.
 - Miscellaneous fixes.
 
 ## [5.2.1] - 2016-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fix parsing C preprocessor line continuations.
 - Add parentheses around symbols `(:|)` when required.
 - Support `$p` pattern splices.
-- Fix formatting associated type families.
+- Fix formatting of associated type families.
 - Fix formatting non-dependent record constructors.
 
 ## [5.2.7] - 2019-03-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,7 +198,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Added
 
-- `--tab-size` parameter for indentation spaces.
+- Add `--tab-size` parameter to control indentation spaces.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.3.4]: https://github.com/mihaimaruseac/hindent/compare/v5.3.3...v5.3.4
 [5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
 [5.3.2]: https://github.com/mihaimaruseac/hindent/compare/5.3.1...v5.3.2
-[5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.3.0...v5.3.1
+[5.3.1]: https://github.com/mihaimaruseac/hindent/compare/5.3.0...5.3.1
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fix pretty-printing of `'(:)`.
 - Fix parsing C preprocessor line continuations.
 - Add parentheses around symbols `(:|)` when required.
-- Support $p` pattern splices.
+- Support `$p` pattern splices.
 - Fix formatting associated type families.
 - Fix formatting non-dependent record constructors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.0]: https://github.com/mihaimaruseac/hindent/compare/5.1.1...5.2.0
 [5.1.1]: https://github.com/mihaimaruseac/hindent/compare/5.1.0...5.1.1
 [5.1.0]: https://github.com/mihaimaruseac/hindent/compare/5.0.1...5.1.0
+[5.0.1]: https://github.com/mihaimaruseac/hindent/compare/5.0.0...5.0.1
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fixed pretty-printing for infix data constructors.
 - Fixed pretty-printing of quasi-quoter names.
 - Fixed pretty-printing of complicated type aliases.
-- Fixed pretty-printing complicated type signatures.
+- Fixed pretty-printing of complicated type signatures.
 
 ## [5.2.2] - 2017-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD
 [5.3.4]: https://github.com/mihaimaruseac/hindent/compare/v5.3.3...v5.3.4
 [5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
-[5.3.2]: https://github.com/mihaimaruseac/hindent/compare/v5.3.1...v5.3.2
+[5.3.2]: https://github.com/mihaimaruseac/hindent/compare/5.3.1...v5.3.2
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,13 +165,18 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fixed adding a spurious space for comments at the end of a file.
 - Fixed adding a trailing white space on `<-`
 
-5.2.0:
+## [5.2.0] - 2016-08-30
 
-    * Default tab-width is now 2
-    * Supports .hindent.yaml file to specify alt tab-width and max
-      column
-    * Put last paren of export list on a new line
-    * Implement tab-size support in Emacs Lisp
+### Added
+
+- Support the `.hindent.yaml` file to specify alternative tab width and max
+  column numbers.
+- Implement the tab-size support in Emacs Lisp.
+
+### Changed
+
+- The default number of spaces for a tab is changed to 2.
+- The last parenthesis of an export list is now put on a new line.
 
 5.1.1:
 
@@ -240,6 +245,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.3]: https://github.com/mihaimaruseac/hindent/compare/5.2.2...5.2.3
 [5.2.2]: https://github.com/mihaimaruseac/hindent/compare/5.2.1...5.2.2
 [5.2.1]: https://github.com/mihaimaruseac/hindent/compare/5.2.0...5.2.1
+[5.2.0]: https://github.com/mihaimaruseac/hindent/compare/5.1.1...5.2.0
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@
 
 ### Changed
 
-- Switched the parser from
-  [`haskell-src-exts`](https://hackage.haskell.org/package/haskell-src-exts) to
-  [`ghc-lib-parser`](https://hackage.haskell.org/package/ghc-lib-parser-9.4.1.20220807).
+- Switched the parser from [`haskell-src-exts`] to [`ghc-lib-parser`].
   This switch causes changes in the formatting results in some cases.
 
 ### Removed
@@ -182,3 +180,6 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [#588]: https://github.com/mihaimaruseac/hindent/pull/588
 [#584]: https://github.com/mihaimaruseac/hindent/pull/584
 [#579]: https://github.com/mihaimaruseac/hindent/pull/579
+
+[`haskell-src-exts`]: https://hackage.haskell.org/package/haskell-src-exts
+[`ghc-lib-parser`]: https://hackage.haskell.org/package/ghc-lib-parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.2]: https://github.com/mihaimaruseac/hindent/compare/5.2.1...5.2.2
 [5.2.1]: https://github.com/mihaimaruseac/hindent/compare/5.2.0...5.2.1
 [5.2.0]: https://github.com/mihaimaruseac/hindent/compare/5.1.1...5.2.0
+[5.1.1]: https://github.com/mihaimaruseac/hindent/compare/5.1.0...5.1.1
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,10 +226,6 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Support for styles
 
-5.0.0:
-
-	* Drop support for styles
-
 4.6.4
 
 	* Copy/delete file instead of renaming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Changed
 
-- HIndent now leaves do, lambda, and lambda-case on the previous line of `$`.
+- HIndent now leaves `do`, lambda (`\x->`), and lambda-case (`\case->`) on the previous line of `$`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19
+[@toku-sa-n]: https://github.com/toku-sa-n
 
 [#588]: https://github.com/mihaimaruseac/hindent/pull/588
 [#584]: https://github.com/mihaimaruseac/hindent/pull/584

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Added
 
-- Shebang support (Fixes [#208]).
+- Add shebang support (Fixes [#208]).
 - Output the filename for parse errors (Fixes [#179]).
 - Added a document of the `-X` option (Fixes [#212]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fixed a build with Cabal 3.6 by [@uhbif19] in [#584].
 - Fixed a compile error for GHC 9.2.2 by [@toku-sa-n] in [#588].
 
+## [5.3.2] - 2022-02-02
+
+### Fixed
+
+- `MonadFix` issues to support newer GHC versions.
+
 5.3.0:
     * Handle multiple deriving clauses in a DerivingStrategies scenario
     * Ignore non-files in findCabalFiles
@@ -172,6 +178,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD
 [5.3.4]: https://github.com/mihaimaruseac/hindent/compare/v5.3.3...v5.3.4
 [5.3.3]: https://github.com/mihaimaruseac/hindent/compare/v5.3.2...v5.3.3
+[5.3.2]: https://github.com/mihaimaruseac/hindent/compare/v5.3.1...v5.3.2
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - A bug in the `-X` option
 
-5.2.6:
-    * Switch to optparse-applicative
+## [5.2.6] - 2019-03-16
+
+### Changed
+
+- Switched to [`optparse-applicative`].
 
 5.2.5:
 
@@ -207,3 +210,4 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 [`haskell-src-exts`]: https://hackage.haskell.org/package/haskell-src-exts
 [`ghc-lib-parser`]: https://hackage.haskell.org/package/ghc-lib-parser
+[`optparse-applicative`]: https://hackage.haskell.org/package/optparse-applicative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,18 +115,29 @@ This version is accidentally pushlished, and is the same as 5.3.3.
   `INLINE`/`NOINLINE` pragmas, infix type operators, and infix constructors.
 - Fix extra linebreaks after short identifiers.
 
-5.2.3:
+## [5.2.3] - 2017-05-07
 
-    * Sort explicit import lists
-    * Report the `SrcLoc` when there's a parse error
-    * Improve long type signatures pretty printing
-    * Support custom line-break operators, add `--line-breaks` argument
-    * Fix infix data constructor
-    * Disable `RecursiveDo` and `DoRec` extensions by default
-    * Add RecStmt support
-    * Improve GADT records, data declaration records
-    * Complicated type alias and type signatures pretty printing
-    * Fix quasi-quoter names
+### Added
+
+- HIndent now reports where a parse happened.
+- Support custom the `line-break` option.
+- Added `--line-breaks` parameter.
+- Added the `RecStmt` support
+
+### Changed
+
+- Explicit import lists are now sorted.
+- Improved pretty-printing long type signatures.
+- Improved pretty-printing GADT records.
+- Improved pretty-printing data declaration records.
+- The `RecursiveDo` and `DoRec` extensions are now disabled-by-default.
+
+## Fixed
+
+- Fixed pretty-printing infix data constructors.
+- Fixed pretty-printing quasi-quoter names.
+- Fixed pretty-printing complicated type aliases.
+- Fixed pretty-printing complicated type signatures.
 
 5.2.2:
 
@@ -216,6 +227,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.6]: https://github.com/mihaimaruseac/hindent/compare/5.2.5...5.2.6
 [5.2.5]: https://github.com/mihaimaruseac/hindent/compare/5.2.4...5.2.5
 [5.2.4]: https://github.com/mihaimaruseac/hindent/compare/5.2.3...5.2.4
+[5.2.3]: https://github.com/mihaimaruseac/hindent/compare/5.2.2...5.2.3
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 ### Fixed
 
 - Fixed handling of paragraph overhang when using large constraints.
-- Fixed pretty-printing multi-line comments.
+- Fixed pretty-printing of multi-line comments.
 - Fixed bug resulting in adding a spurious space for comments at the end of a file.
 - Fixed bug which results in adding a trailing white space on `<-`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,22 +92,28 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Fix the `let ... in` bug
 - Fix formatting top-level lambda expressions in `TemplateHaskell` slices
 
-5.2.4:
+## [5.2.4] - 2017-10-20
 
-    * Pretty print imports
-    * Fix pretty print for string literals for `DataKinds`
-    * Support `--validate` option for checking the format without reformatting
-    * Support parse `#include`, `#error`, `#warning` directives
-    * Support read `LANGUAGE` pragma and parse the declared extensions from source
-    * Treat `TypeApplications` extension as 'badExtensions' due to the `@` symbol
-    * Improve pretty print for unboxed tuples
-    * Fix many issues related to infix operators, includes TH name quotes,
-      `INLINE`/`NOINLINE` pragmas, infix type operator and infix constructor
-    * Fix pretty print for operators in `INLINE`/`NOINLINE` pragmas
-    * Support for `EmptyCases` extension
-    * Fix TH name quotes on operator names
-    * Optimize pretty print for many fundeps
-    * Fix extra linebreaks after short identifiers
+### Added
+
+- Improved pretty-printing unboxed tuples.
+- Support the `--validate` option for checking the format without reformatting
+- Support parsing `#include`, `#error`, and `#warning` directives.
+- Support reading `LANGUAGE` pragmas and parse the declared extensions from sources.
+- Support the `EmptyCases` extension
+- Optimize pretty-printing for many functional dependencies.
+
+### Changed
+
+- The `TypeApplications` extension is now disabled-by-default due to the `@` symbol
+
+### Fixed
+
+- Fixed pretty-printing imports
+- Fixed pretty-printing string literals for `DataKinds`
+- Fixed many issues related to infix operators including TH name quotes,
+  `INLINE`/`NOINLINE` pragmas, infix type operators, and infix constructors.
+- Fix extra linebreaks after short identifiers.
 
 5.2.3:
 
@@ -209,6 +215,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.2.7]: https://github.com/mihaimaruseac/hindent/compare/5.2.6...5.2.7
 [5.2.6]: https://github.com/mihaimaruseac/hindent/compare/5.2.5...5.2.6
 [5.2.5]: https://github.com/mihaimaruseac/hindent/compare/5.2.4...5.2.5
+[5.2.4]: https://github.com/mihaimaruseac/hindent/compare/5.2.3...5.2.4
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 - Test functions except `testAst`.
 
+## [5.3.4] - 2022-07-07
+
+This version is accidentally pushlished, and is the same as 5.3.3.
+
 5.3.0:
     * Handle multiple deriving clauses in a DerivingStrategies scenario
     * Ignore non-files in findCabalFiles
@@ -155,3 +159,4 @@
 	* 6x speed up on rendering operators.
 
 [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...HEAD
+[5.3.4]: https://github.com/mihaimaruseac/hindent/compare/v5.3.3...v5.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,9 +242,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Fixed the whole module printer.
 
-4.4.5
+## [4.4.5] - 2015-11-10
 
-	* Fix bug in infix patterns
+### Fixed
+
+- Fixed a bug in infix patterns.
 
 4.4.2
 
@@ -281,6 +283,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.0.0]: https://github.com/mihaimaruseac/hindent/compare/4.6.4...5.0.0
 [4.6.4]: https://github.com/mihaimaruseac/hindent/compare/4.6.3...4.6.4
 [4.6.3]: https://github.com/mihaimaruseac/hindent/compare/4.6.2...4.6.3
+[4.4.5]: https://github.com/mihaimaruseac/hindent/compare/4.4.4...4.4.5
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,10 +232,15 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - The formatted file is now created by coping/deleting a file instead of renaming.
 
-4.4.6
+## [4.6.3] - 2016-04-18
 
-	* Fix whole module printer
-	* Accept a filename to reformat
+### Added
+
+- Accept a filename to reformat.
+
+### Fixed
+
+- Fixed the whole module printer.
 
 4.4.5
 
@@ -275,6 +280,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [5.0.1]: https://github.com/mihaimaruseac/hindent/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/mihaimaruseac/hindent/compare/4.6.4...5.0.0
 [4.6.4]: https://github.com/mihaimaruseac/hindent/compare/4.6.3...4.6.4
+[4.6.3]: https://github.com/mihaimaruseac/hindent/compare/4.6.2...4.6.3
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 - Fixed handling on large constraints.
 - Fixed pretty-printing multi-line comments.
-- Fixed adding a spurious space for comments at the end of a file.
+- Fixed bug resulting in adding a spurious space for comments at the end of a file.
 - Fixed adding a trailing white space on `<-`
 
 ## [5.2.0] - 2016-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,9 +259,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 - Bunch of Gibiansky style bugs.
 - Tibell style bugs.
 
-4.3.8
+## [4.3.8] - 2015-02-06
 
-	* Fixed: bug in printing operators in statements.
+### Fixed
+
+- A bug in printing operators in statements.
 
 4.5.4
 
@@ -290,6 +292,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [4.6.3]: https://github.com/mihaimaruseac/hindent/compare/4.6.2...4.6.3
 [4.4.5]: https://github.com/mihaimaruseac/hindent/compare/4.4.4...4.4.5
 [4.4.2]: https://github.com/mihaimaruseac/hindent/compare/4.4.1...4.4.2
+[4.3.8]: https://github.com/mihaimaruseac/hindent/compare/4.3.7...4.3.8
 
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Added
 
-- Made compatible with GHC 7.8 through to GHC 8.0
+- Made HIndent compatible with GHC 7.8 through GHC 8.0
 - Added test suites and benchmarks in [`TESTS.md`] and [`BENCHMARKS.md`]
 
 ### Changed


### PR DESCRIPTION
This PR reorganizes the changelog to follow [keep a changelog](https://keepachangelog.com/en/1.0.0/). 