### PR TITLE
Change how to format a data type with a record constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Switched the parser from [`haskell-src-exts`] to [`ghc-lib-parser`].
   This switch causes changes in the formatting results in some cases.
+- Changed how to format a data type with a record constructor to follow
+  the [Johan Tibell's Haskell Style Guide]. ([#662]).
 
 ### Removed
 
@@ -300,6 +302,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#662]: https://github.com/mihaimaruseac/hindent/pull/662
 [#588]: https://github.com/mihaimaruseac/hindent/pull/588
 [#584]: https://github.com/mihaimaruseac/hindent/pull/584
 [#579]: https://github.com/mihaimaruseac/hindent/pull/579
@@ -319,3 +322,5 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 [`TESTS.md`]: TESTS.md
 [`BENCHMARKS.md`]: BENCHMARKS.md
+
+[Johan Tibell's Haskell Style Guide]: https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md

--- a/TESTS.md
+++ b/TESTS.md
@@ -624,11 +624,10 @@ instance (:?:) Int Bool
 Data declaration with underscore
 
 ```haskell
-data Stanza =
-  MkStanza
-    { _stanzaBuildInfo :: BuildInfo
-    , stanzaIsSourceFilePath :: FilePath -> Bool
-    }
+data Stanza = MkStanza
+  { _stanzaBuildInfo :: BuildInfo
+  , stanzaIsSourceFilePath :: FilePath -> Bool
+  }
 ```
 
 A data declaration with typeclass constraints
@@ -642,10 +641,9 @@ data Ord a =>
 Multiple constructors at once
 
 ```haskell
-data Foo =
-  Foo
-    { foo, bar, baz, qux, quux :: Int
-    }
+data Foo = Foo
+  { foo, bar, baz, qux, quux :: Int
+  }
 ```
 
 No fields
@@ -697,10 +695,9 @@ data Foo =
 A record constructor with a field
 
 ```haskell
-data Foo =
-  Foo
-    { foo :: Int
-    }
+data Foo = Foo
+  { foo :: Int
+  }
 ```
 
 Multiple constructors with fields
@@ -749,28 +746,25 @@ data Foo =
 An `UNPACK`ed field.
 
 ```haskell
-data Foo =
-  Foo
-    { x :: {-# UNPACK #-} Int
-    }
+data Foo = Foo
+  { x :: {-# UNPACK #-} Int
+  }
 ```
 
 An `NOUNPACK`ed field.
 
 ```haskell
-data Foo =
-  Foo
-    { x :: {-# NOUNPACK #-} !Int
-    }
+data Foo = Foo
+  { x :: {-# NOUNPACK #-} !Int
+  }
 ```
 
 A lazy field.
 
 ```haskell
-data Foo =
-  Foo
-    { x :: ~Int
-    }
+data Foo = Foo
+  { x :: ~Int
+  }
 ```
 
 #### Fields with `forall` constraints
@@ -818,13 +812,11 @@ With a record constructor
 
 ```haskell
 -- From https://github.com/mihaimaruseac/hindent/issues/167
-data Person =
-  Person
-    { firstName :: !String -- ^ First name
-    , lastName :: !String -- ^ Last name
-    , age :: !Int -- ^ Age
-    }
-  deriving (Eq, Show)
+data Person = Person
+  { firstName :: !String -- ^ First name
+  , lastName :: !String -- ^ Last name
+  , age :: !Int -- ^ Age
+  } deriving (Eq, Show)
 ```
 
 Multiple derivings
@@ -2785,11 +2777,10 @@ f = undefined
 ```haskell since 9.2.2
 {-# LANGUAGE OverloadedRecordDot #-}
 
-data Rectangle =
-  Rectangle
-    { width :: Int
-    , height :: Int
-    }
+data Rectangle = Rectangle
+  { width :: Int
+  , height :: Int
+  }
 
 area :: Rectangle -> Int
 area r = r.width * r.height
@@ -2994,19 +2985,18 @@ data X
   = X -- ^ X is for xylophone.
   | Y -- ^ Y is for why did I eat that pizza.
 
-data X =
-  X
-    { field1 :: Int -- ^ Field1 is the first field.
-    , field11 :: Char
-      -- ^ This field comment is on its own line.
-    , field2 :: Int -- ^ Field2 is the second field.
-    , field3 :: Char -- ^ This is a long comment which starts next to
-      -- the field but continues onto the next line, it aligns exactly
-      -- with the field name.
-    , field4 :: Char
-      -- ^ This is a long comment which starts on the following line
-      -- from from the field, lines continue at the sme column.
-    }
+data X = X
+  { field1 :: Int -- ^ Field1 is the first field.
+  , field11 :: Char
+    -- ^ This field comment is on its own line.
+  , field2 :: Int -- ^ Field2 is the second field.
+  , field3 :: Char -- ^ This is a long comment which starts next to
+    -- the field but continues onto the next line, it aligns exactly
+    -- with the field name.
+  , field4 :: Char
+    -- ^ This is a long comment which starts on the following line
+    -- from from the field, lines continue at the sme column.
+  }
 
 foo ::
      String -- ^ Reason for eating pizza.

--- a/src/HIndent/CabalFile.hs
+++ b/src/HIndent/CabalFile.hs
@@ -28,11 +28,10 @@ import Language.Haskell.Extension hiding (Extension)
 import System.Directory
 import System.FilePath
 
-data Stanza =
-  MkStanza
-    { _stanzaBuildInfo :: BuildInfo
-    , stanzaIsSourceFilePath :: FilePath -> Bool
-    }
+data Stanza = MkStanza
+  { _stanzaBuildInfo :: BuildInfo
+  , stanzaIsSourceFilePath :: FilePath -> Bool
+  }
 
 -- | Find the relative path of a child path in a parent, if it is a child
 toRelative :: FilePath -> FilePath -> Maybe FilePath

--- a/src/HIndent/Config.hs
+++ b/src/HIndent/Config.hs
@@ -20,16 +20,15 @@ import qualified Path.IO as Path
 
 -- | Configurations shared among the different styles. Styles may pay
 -- attention to or completely disregard this configuration.
-data Config =
-  Config
-    { configMaxColumns :: !Int64 -- ^ Maximum columns to fit code into ideally.
-    , configIndentSpaces :: !Int64 -- ^ How many spaces to indent?
-    , configTrailingNewline :: !Bool -- ^ End with a newline.
-    , configSortImports :: !Bool -- ^ Sort imports in groups.
-    , configLineBreaks :: [String] -- ^ Break line when meets these operators.
-    , configExtensions :: [Extension]
+data Config = Config
+  { configMaxColumns :: !Int64 -- ^ Maximum columns to fit code into ideally.
+  , configIndentSpaces :: !Int64 -- ^ How many spaces to indent?
+  , configTrailingNewline :: !Bool -- ^ End with a newline.
+  , configSortImports :: !Bool -- ^ Sort imports in groups.
+  , configLineBreaks :: [String] -- ^ Break line when meets these operators.
+  , configExtensions :: [Extension]
       -- ^ Extra language extensions enabled by default.
-    }
+  }
 
 instance FromJSON Config where
   parseJSON (Y.Object v) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Pretty printing.
 --
@@ -19,38 +19,38 @@ module HIndent.Pretty
   ( pretty
   ) where
 
-import           Control.Monad
-import           Control.Monad.RWS
-import           Data.Maybe
-import           Data.Void
-import           GHC.Core.Coercion
-import           GHC.Core.InstEnv
-import           GHC.Data.Bag
-import           GHC.Data.BooleanFormula
-import           GHC.Data.FastString
-import           GHC.Hs
-import           GHC.Stack
-import           GHC.Types.Basic
-import           GHC.Types.Fixity
-import           GHC.Types.ForeignCall
-import           GHC.Types.Name
-import           GHC.Types.Name.Reader
-import           GHC.Types.SourceText
-import           GHC.Types.SrcLoc
-import           GHC.Unit
-import           GHC.Unit.Module.Warnings
-import           HIndent.Applicative
-import           HIndent.Config
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.Import
-import           HIndent.Pretty.NodeComments
-import           HIndent.Pretty.Pragma
-import           HIndent.Pretty.SigBindFamily
-import           HIndent.Pretty.Types
-import           HIndent.Printer
-import           Text.Show.Unicode
+import Control.Monad
+import Control.Monad.RWS
+import Data.Maybe
+import Data.Void
+import GHC.Core.Coercion
+import GHC.Core.InstEnv
+import GHC.Data.Bag
+import GHC.Data.BooleanFormula
+import GHC.Data.FastString
+import GHC.Hs
+import GHC.Stack
+import GHC.Types.Basic
+import GHC.Types.Fixity
+import GHC.Types.ForeignCall
+import GHC.Types.Name
+import GHC.Types.Name.Reader
+import GHC.Types.SourceText
+import GHC.Types.SrcLoc
+import GHC.Unit
+import GHC.Unit.Module.Warnings
+import HIndent.Applicative
+import HIndent.Config
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.Import
+import HIndent.Pretty.NodeComments
+import HIndent.Pretty.Pragma
+import HIndent.Pretty.SigBindFamily
+import HIndent.Pretty.Types
+import HIndent.Printer
+import Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-import           GHC.Types.PkgQual
+import GHC.Types.PkgQual
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -147,7 +147,7 @@ instance Pretty HsModule where
           printCommentsAnd exports (vTuple . fmap pretty)
           string " where"
       moduleDeclExists HsModule {hsmodName = Nothing} = False
-      moduleDeclExists _                              = True
+      moduleDeclExists _ = True
       prettyDecls =
         mapM_ (\(x, sp) -> pretty x >> fromMaybe (return ()) sp) $
         addDeclSeparator $ hsmodDecls m
@@ -155,34 +155,34 @@ instance Pretty HsModule where
       addDeclSeparator [x] = [(x, Nothing)]
       addDeclSeparator (x:xs) =
         (x, Just $ declSeparator $ unLoc x) : addDeclSeparator xs
-      declSeparator (SigD _ TypeSig {})   = newline
+      declSeparator (SigD _ TypeSig {}) = newline
       declSeparator (SigD _ InlineSig {}) = newline
-      declSeparator _                     = blankline
+      declSeparator _ = blankline
       declsExist = not . null . hsmodDecls
       prettyImports = importDecls >>= blanklined . fmap outputImportGroup
       outputImportGroup = lined . fmap pretty
       importDecls =
         gets (configSortImports . psConfig) >>= \case
-          True  -> pure $ extractImportsSorted m
+          True -> pure $ extractImportsSorted m
           False -> pure $ extractImports m
 
 instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
 instance Pretty (HsDecl GhcPs) where
-  pretty' (TyClD _ d)      = pretty d
-  pretty' (InstD _ inst)   = pretty inst
-  pretty' (DerivD _ x)     = pretty x
-  pretty' (ValD _ bind)    = pretty bind
-  pretty' (SigD _ s)       = pretty $ DeclSig s
-  pretty' (KindSigD _ x)   = pretty x
-  pretty' (DefD _ x)       = pretty x
-  pretty' (ForD _ x)       = pretty x
-  pretty' (WarningD _ x)   = pretty x
-  pretty' (AnnD _ x)       = pretty x
-  pretty' (RuleD _ x)      = pretty x
-  pretty' (SpliceD _ sp)   = pretty sp
-  pretty' DocD {}          = docNode
+  pretty' (TyClD _ d) = pretty d
+  pretty' (InstD _ inst) = pretty inst
+  pretty' (DerivD _ x) = pretty x
+  pretty' (ValD _ bind) = pretty bind
+  pretty' (SigD _ s) = pretty $ DeclSig s
+  pretty' (KindSigD _ x) = pretty x
+  pretty' (DefD _ x) = pretty x
+  pretty' (ForD _ x) = pretty x
+  pretty' (WarningD _ x) = pretty x
+  pretty' (AnnD _ x) = pretty x
+  pretty' (RuleD _ x) = pretty x
+  pretty' (SpliceD _ sp) = pretty sp
+  pretty' DocD {} = docNode
   pretty' (RoleAnnotD _ x) = pretty x
 
 instance Pretty (TyClDecl GhcPs) where
@@ -226,7 +226,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType  -> string "newtype "
+        NewType -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -241,7 +241,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType  -> string "newtype "
+        NewType -> string "newtype "
 #endif
 prettyTyClDecl ClassDecl {..} = do
   if isJust tcdCtxt
@@ -262,9 +262,9 @@ prettyTyClDecl ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            []  -> string "()"
+            [] -> string "()"
             [x] -> pretty x
-            xs  -> hvTuple $ fmap pretty xs
+            xs -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
@@ -294,19 +294,19 @@ prettyTyClDecl ClassDecl {..} = do
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs []
 
 instance Pretty (InstDecl GhcPs) where
-  pretty' ClsInstD {..}     = pretty cid_inst
+  pretty' ClsInstD {..} = pretty cid_inst
   pretty' DataFamInstD {..} = pretty dfid_inst
-  pretty' TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (HsBind GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: HsBind GhcPs -> Printer ()
-prettyHsBind FunBind {..}     = pretty fun_matches
-prettyHsBind PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind VarBind {}       = notGeneratedByParser
+prettyHsBind FunBind {..} = pretty fun_matches
+prettyHsBind PatBind {..} = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind VarBind {} = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind AbsBinds {}      = notGeneratedByParser
+prettyHsBind AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
 
@@ -435,7 +435,7 @@ instance Pretty (HsDataDefn GhcPs) where
       isGADT =
         case dd_cons of
           (L _ ConDeclGADT {}:_) -> True
-          _                      -> False
+          _ -> False
 
 instance Pretty (ClsInstDecl GhcPs) where
   pretty' ClsInstDecl {..} = do
@@ -485,7 +485,7 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              []         -> error "Invalid function application."
+              [] -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
@@ -530,7 +530,7 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
       prefixedLined "," $
       fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing Missing {} = True
-    isMissing _          = False
+    isMissing _ = False
 prettyHsExpr (ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -555,9 +555,9 @@ prettyHsExpr (HsIf _ cond t f) = do
     branch :: String -> LHsExpr GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (HsDo _ DoExpr {} xs))  -> doStmt "do" xs
+        (L _ (HsDo _ DoExpr {} xs)) -> doStmt "do" xs
         (L _ (HsDo _ MDoExpr {} xs)) -> doStmt "mdo" xs
-        _                            -> string str |=> pretty e
+        _ -> string str |=> pretty e
       where
         doStmt pref stmts = do
           string $ str ++ pref
@@ -703,7 +703,7 @@ prettyHsExpr HsTcBracketOut {} = notGeneratedByParser
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case  -> string "\\case"
+      Case -> string "\\case"
       Cases -> string "\\cases"
     if null $ unLoc $ mg_alts matches
       then string " {}"
@@ -743,7 +743,7 @@ instance Pretty HsSigType' where
     where
       flatten :: LHsType GhcPs -> [LHsType GhcPs]
       flatten (L _ (HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x                       = [x]
+      flatten x = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig HsSig {..}) =
     case sig_bndrs of
       HsOuterExplicit _ xs -> do
@@ -782,10 +782,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -796,18 +796,18 @@ prettyConDecl ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly ctx =
       (pretty (Context ctx) >> string " => " >> horArgs) <-|>
       (pretty (Context ctx) >> prefixed "=> " verArgs)
-
+    
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
           inter (string " -> ") $
           fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
@@ -821,18 +821,18 @@ prettyConDecl ConDeclGADT {..} = do
         (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly _ =
       (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
       (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-
+    
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
           inter (string " -> ") $
           fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
@@ -841,7 +841,7 @@ prettyConDecl ConDeclGADT {..} = do
         RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-
+    
     forallNeeded =
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
@@ -887,7 +887,7 @@ prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
     case unLoc $ head m_pats of
       LazyPat {} -> space
       BangPat {} -> space
-      _          -> return ()
+      _ -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
@@ -922,7 +922,7 @@ prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
     case unLoc $ head m_pats of
       LazyPat {} -> space
       BangPat {} -> space
-      _          -> return ()
+      _ -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -982,7 +982,7 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
     where
       horizontal =
         case rec_dotdot of
-          Just _  -> braces $ string ".."
+          Just _ -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1083,7 +1083,7 @@ prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _  -> hPromotedList $ fmap pretty xs
+    _ -> hPromotedList $ fmap pretty xs
 prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (HsTyLit _ x) = pretty x
 prettyHsType HsWildCardTy {} = string "_"
@@ -1124,20 +1124,20 @@ instance Pretty (HsMatchContext GhcPs) where
   pretty' = prettyHsMatchContext
 
 prettyHsMatchContext :: HsMatchContext GhcPs -> Printer ()
-prettyHsMatchContext FunRhs {..}       = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext LambdaExpr        = return ()
-prettyHsMatchContext CaseAlt           = return ()
-prettyHsMatchContext IfAlt {}          = notGeneratedByParser
+prettyHsMatchContext FunRhs {..} = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext LambdaExpr = return ()
+prettyHsMatchContext CaseAlt = return ()
+prettyHsMatchContext IfAlt {} = notGeneratedByParser
 prettyHsMatchContext ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext PatBindRhs {}     = notGeneratedByParser
-prettyHsMatchContext PatBindGuards {}  = notGeneratedByParser
-prettyHsMatchContext RecUpd {}         = notGeneratedByParser
-prettyHsMatchContext StmtCtxt {}       = notGeneratedByParser
-prettyHsMatchContext ThPatSplice {}    = notGeneratedByParser
-prettyHsMatchContext ThPatQuote {}     = notGeneratedByParser
-prettyHsMatchContext PatSyn {}         = notGeneratedByParser
+prettyHsMatchContext PatBindRhs {} = notGeneratedByParser
+prettyHsMatchContext PatBindGuards {} = notGeneratedByParser
+prettyHsMatchContext RecUpd {} = notGeneratedByParser
+prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
+prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
+prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
+prettyHsMatchContext PatSyn {} = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsMatchContext LamCaseAlt {}     = notUsedInParsedStage
+prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
 #endif
 instance Pretty (ParStmtBlock GhcPs GhcPs) where
   pretty' (ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
@@ -1308,9 +1308,9 @@ prettyPat (SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat HsRecFields {..}) =
     case fieldPrinters of
-      []  -> string "{}"
+      [] -> string "{}"
       [x] -> braces x
-      xs  -> hvFields xs
+      xs -> hvFields xs
     where
       fieldPrinters =
         fmap (pretty . fmap RecConField) rec_flds ++
@@ -1328,10 +1328,10 @@ instance Pretty (HsBracket GhcPs) where
   pretty' (TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x)        = pretty $ DeclSig x
-  pretty' (Bind x)       = pretty x
+  pretty' (Sig x) = pretty $ DeclSig x
+  pretty' (Bind x) = pretty x
   pretty' (TypeFamily x) = pretty x
-  pretty' (TyFamInst x)  = pretty x
+  pretty' (TyFamInst x) = pretty x
 
 instance Pretty EpaComment where
   pretty' EpaComment {..} = pretty ac_tok
@@ -1351,7 +1351,7 @@ instance Pretty (HsValBindsLR GhcPs GhcPs) where
 
 instance Pretty (HsTupArg GhcPs) where
   pretty' (Present _ e) = pretty e
-  pretty' Missing {}    = pure () -- This appears in a tuple section.
+  pretty' Missing {} = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1435,7 +1435,7 @@ instance Pretty (ConDeclField GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (L _ (HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x)                    = pretty' x
+  pretty' (InfixExpr x) = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1487,9 +1487,9 @@ instance Pretty InfixApp where
           _ -> pretty lhs
 
 instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x)    = pretty x
-  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (Var x) = pretty x
+  pretty' (And xs) = hvCommaSep $ fmap pretty xs
+  pretty' (Or xs) = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
 instance Pretty (FieldLabelStrings GhcPs) where
@@ -1497,7 +1497,7 @@ instance Pretty (FieldLabelStrings GhcPs) where
 
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
-  pretty' (Ambiguous _ name)   = pretty name
+  pretty' (Ambiguous _ name) = pretty name
 
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1538,14 +1538,14 @@ instance Pretty (HsDerivingClause GhcPs) where
 
 instance Pretty (DerivClauseTys GhcPs) where
   pretty' (DctSingle _ ty) = parens $ pretty ty
-  pretty' (DctMulti _ ts)  = hvTuple $ fmap pretty ts
+  pretty' (DctMulti _ ts) = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
-  pretty' NoOverlap {}    = notUsedInParsedStage
+  pretty' NoOverlap {} = notUsedInParsedStage
   pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
+  pretty' Overlapping {} = string "{-# OVERLAPPING #-}"
+  pretty' Overlaps {} = string "{-# OVERLAPS #-}"
+  pretty' Incoherent {} = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
@@ -1555,11 +1555,11 @@ instance Pretty (FamilyDecl GhcPs) where
   pretty' FamilyDecl {..} = do
     string $
       case fdInfo of
-        DataFamily          -> "data"
-        OpenTypeFamily      -> "type"
+        DataFamily -> "data"
+        OpenTypeFamily -> "type"
         ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel    -> string " family "
+      TopLevel -> string " family "
       NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> hsq_explicit fdTyVars
@@ -1582,8 +1582,8 @@ instance Pretty (FamilyDecl GhcPs) where
       _ -> pure ()
 
 instance Pretty (FamilyResultSig GhcPs) where
-  pretty' NoSig {}       = pure ()
-  pretty' (KindSig _ x)  = string ":: " >> pretty x
+  pretty' NoSig {} = pure ()
+  pretty' (KindSig _ x) = string ":: " >> pretty x
   pretty' (TyVarSig _ x) = pretty x
 
 instance Pretty (HsTyVarBndr a GhcPs) where
@@ -1649,9 +1649,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (L _ [])  -> parens
+          (L _ []) -> parens
           (L _ [_]) -> id
-          _         -> parens
+          _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(L _ [])) =
@@ -1666,10 +1666,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing        -> id
-          Just (L _ [])  -> parens
+          Nothing -> id
+          Just (L _ []) -> parens
           Just (L _ [_]) -> id
-          Just _         -> parens
+          Just _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1724,9 +1724,9 @@ instance Pretty (FamEqn GhcPs (HsDataDefn GhcPs)) where
 
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 instance Pretty (HsArg (GenLocated SrcSpanAnnA (HsType GhcPs)) (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x)    = pretty x
+  pretty' (HsValArg x) = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {}     = notUsedInParsedStage
+  pretty' HsArgPar {} = notUsedInParsedStage
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
   pretty' (ExpBr _ x) = brackets $ wrapWithBars $ pretty x
@@ -1745,7 +1745,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -1760,9 +1760,9 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 #endif
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName RdrName) where
-  pretty' (IEName name)      = pretty name
+  pretty' (IEName name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name)    = string "type " >> pretty name
+  pretty' (IEType _ name) = string "type " >> pretty name
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (DotFieldOcc GhcPs) where
   pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel (string . unpackFS)
@@ -1855,15 +1855,15 @@ instance Pretty ForeignImport where
 
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
-  pretty' (CExport conv _)                    = pretty conv
+  pretty' (CExport conv _) = pretty conv
 
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
 instance Pretty Safety where
-  pretty' PlaySafe          = string "safe"
+  pretty' PlaySafe = string "safe"
   pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky         = string "unsafe"
+  pretty' PlayRisky = string "unsafe"
 
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ _ (ValueAnnProvenance name) expr) =
@@ -1880,9 +1880,9 @@ instance Pretty (RoleAnnotDecl GhcPs) where
     fmap (maybe (string "_") pretty . unLoc) roles
 
 instance Pretty Role where
-  pretty' Nominal          = string "nominal"
+  pretty' Nominal = string "nominal"
   pretty' Representational = string "representational"
-  pretty' Phantom          = string "phantom"
+  pretty' Phantom = string "phantom"
 
 instance Pretty (TyFamInstDecl GhcPs) where
   pretty' TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -1933,8 +1933,8 @@ instance Pretty InlinePragma where
     pretty inl_inline
     case inl_act of
       ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x  -> space >> brackets (string $ show x)
-      _                -> pure ()
+      ActiveAfter _ x -> space >> brackets (string $ show x)
+      _ -> pure ()
 
 instance Pretty InlineSpec where
   pretty' = prettyInlineSpec
@@ -1950,21 +1950,21 @@ prettyInlineSpec NoUserInlinePrag =
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (HsPatSynDir GhcPs) where
-  pretty' Unidirectional           = string "<-"
-  pretty' ImplicitBidirectional    = string "="
+  pretty' Unidirectional = string "<-"
+  pretty' ImplicitBidirectional = string "="
   pretty' ExplicitBidirectional {} = string "<-"
 
 instance Pretty (HsOverLit GhcPs) where
   pretty' OverLit {..} = pretty ol_val
 
 instance Pretty OverLitVal where
-  pretty' (HsIntegral x)   = pretty x
+  pretty' (HsIntegral x) = pretty x
   pretty' (HsFractional x) = pretty x
   pretty' (HsIsString _ x) = string $ unpackFS x
 
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..}                     = string $ show il_value
+  pretty' IL {..} = string $ show il_value
 
 instance Pretty FractionalLit where
   pretty' = output
@@ -1983,7 +1983,7 @@ instance Pretty (HsLit GhcPs) where
   pretty' HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      HsString {}     -> prettyString
+      HsString {} -> prettyString
       HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2004,8 +2004,8 @@ instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
 
 instance Pretty HsTyLit where
-  pretty' (HsNumTy _ x)  = string $ show x
-  pretty' (HsStrTy _ x)  = string $ ushow x
+  pretty' (HsNumTy _ x) = string $ show x
+  pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 
 instance Pretty (HsPatSigType GhcPs) where
@@ -2027,10 +2027,10 @@ prettyIPBind (IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (DerivStrategy GhcPs) where
-  pretty' StockStrategy {}    = string "stock"
+  pretty' StockStrategy {} = string "stock"
   pretty' AnyclassStrategy {} = string "anyclass"
-  pretty' NewtypeStrategy {}  = string "newtype"
-  pretty' (ViaStrategy x)     = string "via " >> pretty x
+  pretty' NewtypeStrategy {} = string "newtype"
+  pretty' (ViaStrategy x) = string "via " >> pretty x
 
 instance Pretty XViaStrategyPs where
   pretty' (XViaStrategyPs _ ty) = pretty ty
@@ -2117,7 +2117,7 @@ instance Pretty DoExpression where
     where
       pref =
         case doOrMdo of
-          Do  -> "do"
+          Do -> "do"
           Mdo -> "mdo"
 
 instance Pretty LetIn where
@@ -2130,10 +2130,10 @@ instance Pretty (RuleBndr GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
-  pretty' CCallConv          = string "ccall"
-  pretty' CApiConv           = string "capi"
-  pretty' StdCallConv        = string "stdcall"
-  pretty' PrimCallConv       = string "prim"
+  pretty' CCallConv = string "ccall"
+  pretty' CApiConv = string "capi"
+  pretty' StdCallConv = string "stdcall"
+  pretty' PrimCallConv = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
 
 instance Pretty ModuleDeprecatedPragma where
@@ -2149,13 +2149,13 @@ instance Pretty HsSrcBang where
     pretty strictness
 
 instance Pretty SrcUnpackedness where
-  pretty' SrcUnpack   = string "{-# UNPACK #-}"
+  pretty' SrcUnpack = string "{-# UNPACK #-}"
   pretty' SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' NoSrcUnpack = pure ()
 
 instance Pretty SrcStrictness where
-  pretty' SrcLazy     = string "~"
-  pretty' SrcStrict   = string "!"
+  pretty' SrcLazy = string "~"
+  pretty' SrcStrict = string "!"
   pretty' NoSrcStrict = pure ()
 
 instance Pretty (HsOuterSigTyVarBndrs GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 -- | Pretty printing.
 --
@@ -19,38 +19,38 @@ module HIndent.Pretty
   ( pretty
   ) where
 
-import Control.Monad
-import Control.Monad.RWS
-import Data.Maybe
-import Data.Void
-import GHC.Core.Coercion
-import GHC.Core.InstEnv
-import GHC.Data.Bag
-import GHC.Data.BooleanFormula
-import GHC.Data.FastString
-import GHC.Hs
-import GHC.Stack
-import GHC.Types.Basic
-import GHC.Types.Fixity
-import GHC.Types.ForeignCall
-import GHC.Types.Name
-import GHC.Types.Name.Reader
-import GHC.Types.SourceText
-import GHC.Types.SrcLoc
-import GHC.Unit
-import GHC.Unit.Module.Warnings
-import HIndent.Applicative
-import HIndent.Config
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.Import
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.Pragma
-import HIndent.Pretty.SigBindFamily
-import HIndent.Pretty.Types
-import HIndent.Printer
-import Text.Show.Unicode
+import           Control.Monad
+import           Control.Monad.RWS
+import           Data.Maybe
+import           Data.Void
+import           GHC.Core.Coercion
+import           GHC.Core.InstEnv
+import           GHC.Data.Bag
+import           GHC.Data.BooleanFormula
+import           GHC.Data.FastString
+import           GHC.Hs
+import           GHC.Stack
+import           GHC.Types.Basic
+import           GHC.Types.Fixity
+import           GHC.Types.ForeignCall
+import           GHC.Types.Name
+import           GHC.Types.Name.Reader
+import           GHC.Types.SourceText
+import           GHC.Types.SrcLoc
+import           GHC.Unit
+import           GHC.Unit.Module.Warnings
+import           HIndent.Applicative
+import           HIndent.Config
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.Import
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.Pragma
+import           HIndent.Pretty.SigBindFamily
+import           HIndent.Pretty.Types
+import           HIndent.Printer
+import           Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-import GHC.Types.PkgQual
+import           GHC.Types.PkgQual
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -147,7 +147,7 @@ instance Pretty HsModule where
           printCommentsAnd exports (vTuple . fmap pretty)
           string " where"
       moduleDeclExists HsModule {hsmodName = Nothing} = False
-      moduleDeclExists _ = True
+      moduleDeclExists _                              = True
       prettyDecls =
         mapM_ (\(x, sp) -> pretty x >> fromMaybe (return ()) sp) $
         addDeclSeparator $ hsmodDecls m
@@ -155,34 +155,34 @@ instance Pretty HsModule where
       addDeclSeparator [x] = [(x, Nothing)]
       addDeclSeparator (x:xs) =
         (x, Just $ declSeparator $ unLoc x) : addDeclSeparator xs
-      declSeparator (SigD _ TypeSig {}) = newline
+      declSeparator (SigD _ TypeSig {})   = newline
       declSeparator (SigD _ InlineSig {}) = newline
-      declSeparator _ = blankline
+      declSeparator _                     = blankline
       declsExist = not . null . hsmodDecls
       prettyImports = importDecls >>= blanklined . fmap outputImportGroup
       outputImportGroup = lined . fmap pretty
       importDecls =
         gets (configSortImports . psConfig) >>= \case
-          True -> pure $ extractImportsSorted m
+          True  -> pure $ extractImportsSorted m
           False -> pure $ extractImports m
 
 instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
 instance Pretty (HsDecl GhcPs) where
-  pretty' (TyClD _ d) = pretty d
-  pretty' (InstD _ inst) = pretty inst
-  pretty' (DerivD _ x) = pretty x
-  pretty' (ValD _ bind) = pretty bind
-  pretty' (SigD _ s) = pretty $ DeclSig s
-  pretty' (KindSigD _ x) = pretty x
-  pretty' (DefD _ x) = pretty x
-  pretty' (ForD _ x) = pretty x
-  pretty' (WarningD _ x) = pretty x
-  pretty' (AnnD _ x) = pretty x
-  pretty' (RuleD _ x) = pretty x
-  pretty' (SpliceD _ sp) = pretty sp
-  pretty' DocD {} = docNode
+  pretty' (TyClD _ d)      = pretty d
+  pretty' (InstD _ inst)   = pretty inst
+  pretty' (DerivD _ x)     = pretty x
+  pretty' (ValD _ bind)    = pretty bind
+  pretty' (SigD _ s)       = pretty $ DeclSig s
+  pretty' (KindSigD _ x)   = pretty x
+  pretty' (DefD _ x)       = pretty x
+  pretty' (ForD _ x)       = pretty x
+  pretty' (WarningD _ x)   = pretty x
+  pretty' (AnnD _ x)       = pretty x
+  pretty' (RuleD _ x)      = pretty x
+  pretty' (SpliceD _ sp)   = pretty sp
+  pretty' DocD {}          = docNode
   pretty' (RoleAnnotD _ x) = pretty x
 
 instance Pretty (TyClDecl GhcPs) where
@@ -226,7 +226,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType -> string "newtype "
+        NewType  -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -241,7 +241,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType -> string "newtype "
+        NewType  -> string "newtype "
 #endif
 prettyTyClDecl ClassDecl {..} = do
   if isJust tcdCtxt
@@ -262,9 +262,9 @@ prettyTyClDecl ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            [] -> string "()"
+            []  -> string "()"
             [x] -> pretty x
-            xs -> hvTuple $ fmap pretty xs
+            xs  -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
@@ -294,19 +294,19 @@ prettyTyClDecl ClassDecl {..} = do
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs []
 
 instance Pretty (InstDecl GhcPs) where
-  pretty' ClsInstD {..} = pretty cid_inst
+  pretty' ClsInstD {..}     = pretty cid_inst
   pretty' DataFamInstD {..} = pretty dfid_inst
-  pretty' TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (HsBind GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: HsBind GhcPs -> Printer ()
-prettyHsBind FunBind {..} = pretty fun_matches
-prettyHsBind PatBind {..} = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind VarBind {} = notGeneratedByParser
+prettyHsBind FunBind {..}     = pretty fun_matches
+prettyHsBind PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind VarBind {}       = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind AbsBinds {} = notGeneratedByParser
+prettyHsBind AbsBinds {}      = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
 
@@ -406,24 +406,36 @@ instance Pretty (HsDataDefn GhcPs) where
           pretty x
         string " where"
         indentedBlock $ newlinePrefixed $ fmap pretty dd_cons
-      else indentedBlock $ do
-             case dd_cons of
-               [] -> pure ()
-               [x] -> do
-                 string " ="
-                 newline
-                 pretty x
-               _ -> do
-                 newline
-                 string "= " |=> vBarSep (fmap pretty dd_cons)
-             unless (null dd_derivs) $ do
-               newline
-               lined $ fmap pretty dd_derivs
+      else do
+        case dd_cons of
+          [] ->
+            unless (null dd_derivs) $ do
+              newline
+              indentedBlock $ lined $ fmap pretty dd_derivs
+          [x@(L _ ConDeclH98 {con_args = RecCon {}})] -> do
+            string " = "
+            pretty x
+            unless (null dd_derivs) $ space |=> lined (fmap pretty dd_derivs)
+          [x] -> do
+            string " ="
+            newline
+            indentedBlock $ do
+              pretty x
+              unless (null dd_derivs) $ do
+                newline
+                lined $ fmap pretty dd_derivs
+          _ -> do
+            newline
+            indentedBlock $ do
+              string "= " |=> vBarSep (fmap pretty dd_cons)
+              unless (null dd_derivs) $ do
+                newline
+                lined $ fmap pretty dd_derivs
     where
       isGADT =
         case dd_cons of
           (L _ ConDeclGADT {}:_) -> True
-          _ -> False
+          _                      -> False
 
 instance Pretty (ClsInstDecl GhcPs) where
   pretty' ClsInstDecl {..} = do
@@ -473,7 +485,7 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              [] -> error "Invalid function application."
+              []         -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
@@ -518,7 +530,7 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
       prefixedLined "," $
       fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing Missing {} = True
-    isMissing _ = False
+    isMissing _          = False
 prettyHsExpr (ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -543,9 +555,9 @@ prettyHsExpr (HsIf _ cond t f) = do
     branch :: String -> LHsExpr GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (HsDo _ DoExpr {} xs)) -> doStmt "do" xs
+        (L _ (HsDo _ DoExpr {} xs))  -> doStmt "do" xs
         (L _ (HsDo _ MDoExpr {} xs)) -> doStmt "mdo" xs
-        _ -> string str |=> pretty e
+        _                            -> string str |=> pretty e
       where
         doStmt pref stmts = do
           string $ str ++ pref
@@ -691,7 +703,7 @@ prettyHsExpr HsTcBracketOut {} = notGeneratedByParser
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case -> string "\\case"
+      Case  -> string "\\case"
       Cases -> string "\\cases"
     if null $ unLoc $ mg_alts matches
       then string " {}"
@@ -731,7 +743,7 @@ instance Pretty HsSigType' where
     where
       flatten :: LHsType GhcPs -> [LHsType GhcPs]
       flatten (L _ (HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x = [x]
+      flatten x                       = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig HsSig {..}) =
     case sig_bndrs of
       HsOuterExplicit _ xs -> do
@@ -770,10 +782,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -784,18 +796,18 @@ prettyConDecl ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly ctx =
       (pretty (Context ctx) >> string " => " >> horArgs) <-|>
       (pretty (Context ctx) >> prefixed "=> " verArgs)
-    
+
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
           inter (string " -> ") $
           fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
@@ -809,18 +821,18 @@ prettyConDecl ConDeclGADT {..} = do
         (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly _ =
       (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
       (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-    
+
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
           inter (string " -> ") $
           fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
@@ -829,7 +841,7 @@ prettyConDecl ConDeclGADT {..} = do
         RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-    
+
     forallNeeded =
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
@@ -875,7 +887,7 @@ prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
     case unLoc $ head m_pats of
       LazyPat {} -> space
       BangPat {} -> space
-      _ -> return ()
+      _          -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
@@ -910,7 +922,7 @@ prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
     case unLoc $ head m_pats of
       LazyPat {} -> space
       BangPat {} -> space
-      _ -> return ()
+      _          -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -970,7 +982,7 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
     where
       horizontal =
         case rec_dotdot of
-          Just _ -> braces $ string ".."
+          Just _  -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1071,7 +1083,7 @@ prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _ -> hPromotedList $ fmap pretty xs
+    _  -> hPromotedList $ fmap pretty xs
 prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (HsTyLit _ x) = pretty x
 prettyHsType HsWildCardTy {} = string "_"
@@ -1112,20 +1124,20 @@ instance Pretty (HsMatchContext GhcPs) where
   pretty' = prettyHsMatchContext
 
 prettyHsMatchContext :: HsMatchContext GhcPs -> Printer ()
-prettyHsMatchContext FunRhs {..} = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext LambdaExpr = return ()
-prettyHsMatchContext CaseAlt = return ()
-prettyHsMatchContext IfAlt {} = notGeneratedByParser
+prettyHsMatchContext FunRhs {..}       = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext LambdaExpr        = return ()
+prettyHsMatchContext CaseAlt           = return ()
+prettyHsMatchContext IfAlt {}          = notGeneratedByParser
 prettyHsMatchContext ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext PatBindRhs {} = notGeneratedByParser
-prettyHsMatchContext PatBindGuards {} = notGeneratedByParser
-prettyHsMatchContext RecUpd {} = notGeneratedByParser
-prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
-prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
-prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
-prettyHsMatchContext PatSyn {} = notGeneratedByParser
+prettyHsMatchContext PatBindRhs {}     = notGeneratedByParser
+prettyHsMatchContext PatBindGuards {}  = notGeneratedByParser
+prettyHsMatchContext RecUpd {}         = notGeneratedByParser
+prettyHsMatchContext StmtCtxt {}       = notGeneratedByParser
+prettyHsMatchContext ThPatSplice {}    = notGeneratedByParser
+prettyHsMatchContext ThPatQuote {}     = notGeneratedByParser
+prettyHsMatchContext PatSyn {}         = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
+prettyHsMatchContext LamCaseAlt {}     = notUsedInParsedStage
 #endif
 instance Pretty (ParStmtBlock GhcPs GhcPs) where
   pretty' (ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
@@ -1296,9 +1308,9 @@ prettyPat (SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat HsRecFields {..}) =
     case fieldPrinters of
-      [] -> string "{}"
+      []  -> string "{}"
       [x] -> braces x
-      xs -> hvFields xs
+      xs  -> hvFields xs
     where
       fieldPrinters =
         fmap (pretty . fmap RecConField) rec_flds ++
@@ -1316,10 +1328,10 @@ instance Pretty (HsBracket GhcPs) where
   pretty' (TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x) = pretty $ DeclSig x
-  pretty' (Bind x) = pretty x
+  pretty' (Sig x)        = pretty $ DeclSig x
+  pretty' (Bind x)       = pretty x
   pretty' (TypeFamily x) = pretty x
-  pretty' (TyFamInst x) = pretty x
+  pretty' (TyFamInst x)  = pretty x
 
 instance Pretty EpaComment where
   pretty' EpaComment {..} = pretty ac_tok
@@ -1339,7 +1351,7 @@ instance Pretty (HsValBindsLR GhcPs GhcPs) where
 
 instance Pretty (HsTupArg GhcPs) where
   pretty' (Present _ e) = pretty e
-  pretty' Missing {} = pure () -- This appears in a tuple section.
+  pretty' Missing {}    = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1423,7 +1435,7 @@ instance Pretty (ConDeclField GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (L _ (HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x) = pretty' x
+  pretty' (InfixExpr x)                    = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1475,9 +1487,9 @@ instance Pretty InfixApp where
           _ -> pretty lhs
 
 instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x) = pretty x
-  pretty' (And xs) = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs) = hvBarSep $ fmap pretty xs
+  pretty' (Var x)    = pretty x
+  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
 instance Pretty (FieldLabelStrings GhcPs) where
@@ -1485,7 +1497,7 @@ instance Pretty (FieldLabelStrings GhcPs) where
 
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
-  pretty' (Ambiguous _ name) = pretty name
+  pretty' (Ambiguous _ name)   = pretty name
 
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1526,14 +1538,14 @@ instance Pretty (HsDerivingClause GhcPs) where
 
 instance Pretty (DerivClauseTys GhcPs) where
   pretty' (DctSingle _ ty) = parens $ pretty ty
-  pretty' (DctMulti _ ts) = hvTuple $ fmap pretty ts
+  pretty' (DctMulti _ ts)  = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
-  pretty' NoOverlap {} = notUsedInParsedStage
+  pretty' NoOverlap {}    = notUsedInParsedStage
   pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {} = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {} = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {} = string "{-# INCOHERENT #-}"
+  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
+  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
+  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
@@ -1543,11 +1555,11 @@ instance Pretty (FamilyDecl GhcPs) where
   pretty' FamilyDecl {..} = do
     string $
       case fdInfo of
-        DataFamily -> "data"
-        OpenTypeFamily -> "type"
+        DataFamily          -> "data"
+        OpenTypeFamily      -> "type"
         ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel -> string " family "
+      TopLevel    -> string " family "
       NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> hsq_explicit fdTyVars
@@ -1570,8 +1582,8 @@ instance Pretty (FamilyDecl GhcPs) where
       _ -> pure ()
 
 instance Pretty (FamilyResultSig GhcPs) where
-  pretty' NoSig {} = pure ()
-  pretty' (KindSig _ x) = string ":: " >> pretty x
+  pretty' NoSig {}       = pure ()
+  pretty' (KindSig _ x)  = string ":: " >> pretty x
   pretty' (TyVarSig _ x) = pretty x
 
 instance Pretty (HsTyVarBndr a GhcPs) where
@@ -1637,9 +1649,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (L _ []) -> parens
+          (L _ [])  -> parens
           (L _ [_]) -> id
-          _ -> parens
+          _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(L _ [])) =
@@ -1654,10 +1666,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing -> id
-          Just (L _ []) -> parens
+          Nothing        -> id
+          Just (L _ [])  -> parens
           Just (L _ [_]) -> id
-          Just _ -> parens
+          Just _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1712,9 +1724,9 @@ instance Pretty (FamEqn GhcPs (HsDataDefn GhcPs)) where
 
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 instance Pretty (HsArg (GenLocated SrcSpanAnnA (HsType GhcPs)) (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x) = pretty x
+  pretty' (HsValArg x)    = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {} = notUsedInParsedStage
+  pretty' HsArgPar {}     = notUsedInParsedStage
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
   pretty' (ExpBr _ x) = brackets $ wrapWithBars $ pretty x
@@ -1733,7 +1745,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -1748,9 +1760,9 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 #endif
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName RdrName) where
-  pretty' (IEName name) = pretty name
+  pretty' (IEName name)      = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name) = string "type " >> pretty name
+  pretty' (IEType _ name)    = string "type " >> pretty name
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (DotFieldOcc GhcPs) where
   pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel (string . unpackFS)
@@ -1843,15 +1855,15 @@ instance Pretty ForeignImport where
 
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
-  pretty' (CExport conv _) = pretty conv
+  pretty' (CExport conv _)                    = pretty conv
 
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
 instance Pretty Safety where
-  pretty' PlaySafe = string "safe"
+  pretty' PlaySafe          = string "safe"
   pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky = string "unsafe"
+  pretty' PlayRisky         = string "unsafe"
 
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ _ (ValueAnnProvenance name) expr) =
@@ -1868,9 +1880,9 @@ instance Pretty (RoleAnnotDecl GhcPs) where
     fmap (maybe (string "_") pretty . unLoc) roles
 
 instance Pretty Role where
-  pretty' Nominal = string "nominal"
+  pretty' Nominal          = string "nominal"
   pretty' Representational = string "representational"
-  pretty' Phantom = string "phantom"
+  pretty' Phantom          = string "phantom"
 
 instance Pretty (TyFamInstDecl GhcPs) where
   pretty' TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -1921,8 +1933,8 @@ instance Pretty InlinePragma where
     pretty inl_inline
     case inl_act of
       ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x -> space >> brackets (string $ show x)
-      _ -> pure ()
+      ActiveAfter _ x  -> space >> brackets (string $ show x)
+      _                -> pure ()
 
 instance Pretty InlineSpec where
   pretty' = prettyInlineSpec
@@ -1938,21 +1950,21 @@ prettyInlineSpec NoUserInlinePrag =
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (HsPatSynDir GhcPs) where
-  pretty' Unidirectional = string "<-"
-  pretty' ImplicitBidirectional = string "="
+  pretty' Unidirectional           = string "<-"
+  pretty' ImplicitBidirectional    = string "="
   pretty' ExplicitBidirectional {} = string "<-"
 
 instance Pretty (HsOverLit GhcPs) where
   pretty' OverLit {..} = pretty ol_val
 
 instance Pretty OverLitVal where
-  pretty' (HsIntegral x) = pretty x
+  pretty' (HsIntegral x)   = pretty x
   pretty' (HsFractional x) = pretty x
   pretty' (HsIsString _ x) = string $ unpackFS x
 
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..} = string $ show il_value
+  pretty' IL {..}                     = string $ show il_value
 
 instance Pretty FractionalLit where
   pretty' = output
@@ -1971,7 +1983,7 @@ instance Pretty (HsLit GhcPs) where
   pretty' HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      HsString {} -> prettyString
+      HsString {}     -> prettyString
       HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -1992,8 +2004,8 @@ instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
 
 instance Pretty HsTyLit where
-  pretty' (HsNumTy _ x) = string $ show x
-  pretty' (HsStrTy _ x) = string $ ushow x
+  pretty' (HsNumTy _ x)  = string $ show x
+  pretty' (HsStrTy _ x)  = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 
 instance Pretty (HsPatSigType GhcPs) where
@@ -2015,10 +2027,10 @@ prettyIPBind (IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (DerivStrategy GhcPs) where
-  pretty' StockStrategy {} = string "stock"
+  pretty' StockStrategy {}    = string "stock"
   pretty' AnyclassStrategy {} = string "anyclass"
-  pretty' NewtypeStrategy {} = string "newtype"
-  pretty' (ViaStrategy x) = string "via " >> pretty x
+  pretty' NewtypeStrategy {}  = string "newtype"
+  pretty' (ViaStrategy x)     = string "via " >> pretty x
 
 instance Pretty XViaStrategyPs where
   pretty' (XViaStrategyPs _ ty) = pretty ty
@@ -2105,7 +2117,7 @@ instance Pretty DoExpression where
     where
       pref =
         case doOrMdo of
-          Do -> "do"
+          Do  -> "do"
           Mdo -> "mdo"
 
 instance Pretty LetIn where
@@ -2118,10 +2130,10 @@ instance Pretty (RuleBndr GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
-  pretty' CCallConv = string "ccall"
-  pretty' CApiConv = string "capi"
-  pretty' StdCallConv = string "stdcall"
-  pretty' PrimCallConv = string "prim"
+  pretty' CCallConv          = string "ccall"
+  pretty' CApiConv           = string "capi"
+  pretty' StdCallConv        = string "stdcall"
+  pretty' PrimCallConv       = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
 
 instance Pretty ModuleDeprecatedPragma where
@@ -2137,13 +2149,13 @@ instance Pretty HsSrcBang where
     pretty strictness
 
 instance Pretty SrcUnpackedness where
-  pretty' SrcUnpack = string "{-# UNPACK #-}"
+  pretty' SrcUnpack   = string "{-# UNPACK #-}"
   pretty' SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' NoSrcUnpack = pure ()
 
 instance Pretty SrcStrictness where
-  pretty' SrcLazy = string "~"
-  pretty' SrcStrict = string "!"
+  pretty' SrcLazy     = string "~"
+  pretty' SrcStrict   = string "!"
   pretty' NoSrcStrict = pure ()
 
 instance Pretty (HsOuterSigTyVarBndrs GhcPs) where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -408,10 +408,7 @@ instance Pretty (HsDataDefn GhcPs) where
         indentedBlock $ newlinePrefixed $ fmap pretty dd_cons
       else do
         case dd_cons of
-          [] ->
-            unless (null dd_derivs) $ do
-              newline
-              indentedBlock $ lined $ fmap pretty dd_derivs
+          [] -> indentedBlock derivingsAfterNewline
           [x@(L _ ConDeclH98 {con_args = RecCon {}})] -> do
             string " = "
             pretty x
@@ -421,21 +418,21 @@ instance Pretty (HsDataDefn GhcPs) where
             newline
             indentedBlock $ do
               pretty x
-              unless (null dd_derivs) $ do
-                newline
-                lined $ fmap pretty dd_derivs
+              derivingsAfterNewline
           _ -> do
             newline
             indentedBlock $ do
               string "= " |=> vBarSep (fmap pretty dd_cons)
-              unless (null dd_derivs) $ do
-                newline
-                lined $ fmap pretty dd_derivs
+              derivingsAfterNewline
     where
       isGADT =
         case dd_cons of
           (L _ ConDeclGADT {}:_) -> True
           _ -> False
+      derivingsAfterNewline =
+        unless (null dd_derivs) $ do
+          newline
+          lined $ fmap pretty dd_derivs
 
 instance Pretty (ClsInstDecl GhcPs) where
   pretty' ClsInstDecl {..} = do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -419,9 +419,9 @@ instance Pretty (HsDataDefn GhcPs) where
             indentedBlock $ do
               pretty x
               derivingsAfterNewline
-          _ -> do
-            newline
+          _ ->
             indentedBlock $ do
+              newline
               string "= " |=> vBarSep (fmap pretty dd_cons)
               derivingsAfterNewline
     where

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -412,7 +412,7 @@ instance Pretty (HsDataDefn GhcPs) where
           [x@(L _ ConDeclH98 {con_args = RecCon {}})] -> do
             string " = "
             pretty x
-            unless (null dd_derivs) $ space |=> lined (fmap pretty dd_derivs)
+            unless (null dd_derivs) $ space |=> printDerivings
           [x] -> do
             string " ="
             newline
@@ -430,9 +430,8 @@ instance Pretty (HsDataDefn GhcPs) where
           (L _ ConDeclGADT {}:_) -> True
           _ -> False
       derivingsAfterNewline =
-        unless (null dd_derivs) $ do
-          newline
-          lined $ fmap pretty dd_derivs
+        unless (null dd_derivs) $ newline >> printDerivings
+      printDerivings = lined $ fmap pretty dd_derivs
 
 instance Pretty (ClsInstDecl GhcPs) where
   pretty' ClsInstDecl {..} = do

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -75,28 +75,25 @@ newtype PrefixOp =
 -- > * b
 --
 -- is not a valid Haskell code.
-data InfixApp =
-  InfixApp
-    { lhs :: LHsExpr GhcPs
-    , op :: LHsExpr GhcPs
-    , rhs :: LHsExpr GhcPs
-    , immediatelyAfterDo :: Bool
-    }
+data InfixApp = InfixApp
+  { lhs :: LHsExpr GhcPs
+  , op :: LHsExpr GhcPs
+  , rhs :: LHsExpr GhcPs
+  , immediatelyAfterDo :: Bool
+  }
 
 -- | `GRHSs` with a label indicating in which context the RHS is located
 -- in.
-data GRHSsExpr =
-  GRHSsExpr
-    { grhssExprType :: GRHSExprType
-    , grhssExpr :: GRHSs GhcPs (LHsExpr GhcPs)
-    }
+data GRHSsExpr = GRHSsExpr
+  { grhssExprType :: GRHSExprType
+  , grhssExpr :: GRHSs GhcPs (LHsExpr GhcPs)
+  }
 
 -- | 'GRHS' for a normal binding.
-data GRHSExpr =
-  GRHSExpr
-    { grhsExprType :: GRHSExprType
-    , grhsExpr :: GRHS GhcPs (LHsExpr GhcPs)
-    }
+data GRHSExpr = GRHSExpr
+  { grhsExprType :: GRHSExprType
+  , grhsExpr :: GRHS GhcPs (LHsExpr GhcPs)
+  }
 
 -- | 'GRHS' for a @proc@ binding.
 newtype GRHSProc =
@@ -115,13 +112,12 @@ newtype RecConField =
   RecConField (HsRecField' (FieldOcc GhcPs) (LPat GhcPs))
 #endif
 -- | A wrapper for `HsSigType`.
-data HsSigType' =
-  HsSigType'
-    { hsSigTypeFor :: HsTypeFor -- ^ In which context a `HsSigType` is located in.
-    , hsSigTypeDir :: HsTypeDir -- ^ How a `HsSigType` should be printed;
+data HsSigType' = HsSigType'
+  { hsSigTypeFor :: HsTypeFor -- ^ In which context a `HsSigType` is located in.
+  , hsSigTypeDir :: HsTypeDir -- ^ How a `HsSigType` should be printed;
                                 -- either horizontally or vertically.
-    , hsSigType :: HsSigType GhcPs -- ^ The actual signature.
-    }
+  , hsSigType :: HsSigType GhcPs -- ^ The actual signature.
+  }
 
 -- | `HsSigType'` for instance declarations.
 pattern HsSigTypeInsideInstDecl :: HsSigType GhcPs -> HsSigType'
@@ -139,13 +135,12 @@ pattern HsSigTypeInsideDeclSig :: HsSigType GhcPs -> HsSigType'
 pattern HsSigTypeInsideDeclSig x = HsSigType' HsTypeForDeclSig HsTypeNoDir x
 
 -- | A wrapper for `HsType`.
-data HsType' =
-  HsType'
-    { hsTypeFor :: HsTypeFor -- ^ In which context a `HsType` is located in.
-    , hsTypeDir :: HsTypeDir -- ^ How a function signature is printed;
+data HsType' = HsType'
+  { hsTypeFor :: HsTypeFor -- ^ In which context a `HsType` is located in.
+  , hsTypeDir :: HsTypeDir -- ^ How a function signature is printed;
                              -- either horizontally or vertically.
-    , hsType :: HsType GhcPs -- ^ The actual type.
-    }
+  , hsType :: HsType GhcPs -- ^ The actual type.
+  }
 
 -- | `HsType'` inside a function signature declaration; printed horizontally.
 pattern HsTypeInsideVerticalFuncSig :: HsType GhcPs -> HsType'
@@ -222,11 +217,10 @@ newtype PatInsidePatDecl =
   PatInsidePatDecl (Pat GhcPs)
 
 -- | Lambda case.
-data LambdaCase =
-  LambdaCase
-    { lamCaseGroup :: MatchGroup GhcPs (LHsExpr GhcPs)
-    , caseOrCases :: CaseOrCases
-    }
+data LambdaCase = LambdaCase
+  { lamCaseGroup :: MatchGroup GhcPs (LHsExpr GhcPs)
+  , caseOrCases :: CaseOrCases
+  }
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 -- | A deprecation pragma for a module.
 newtype ModuleDeprecatedPragma =
@@ -237,33 +231,29 @@ newtype ModuleDeprecatedPragma =
   ModuleDeprecatedPragma WarningTxt
 #endif
 -- | Use this type to pretty-print a list comprehension.
-data ListComprehension =
-  ListComprehension
-    { listCompLhs :: ExprLStmt GhcPs -- ^ @f x@ of @[f x| x <- xs]@.
-    , listCompRhs :: [ExprLStmt GhcPs] -- ^ @x <- xs@ of @[f x| x <- xs]@.
-    }
+data ListComprehension = ListComprehension
+  { listCompLhs :: ExprLStmt GhcPs -- ^ @f x@ of @[f x| x <- xs]@.
+  , listCompRhs :: [ExprLStmt GhcPs] -- ^ @x <- xs@ of @[f x| x <- xs]@.
+  }
 
 -- | Use this type to pretty-print a do expression.
-data DoExpression =
-  DoExpression
-    { doStmts :: [ExprLStmt GhcPs]
-    , doOrMdo :: DoOrMdo
-    }
+data DoExpression = DoExpression
+  { doStmts :: [ExprLStmt GhcPs]
+  , doOrMdo :: DoOrMdo
+  }
 
 -- | Use this type to pretty-print a @let ... in ...@ expression.
-data LetIn =
-  LetIn
-    { letBinds :: HsLocalBinds GhcPs
-    , inExpr :: LHsExpr GhcPs
-    }
+data LetIn = LetIn
+  { letBinds :: HsLocalBinds GhcPs
+  , inExpr :: LHsExpr GhcPs
+  }
 
 -- | Comments belonging to an AST node.
-data NodeComments =
-  NodeComments
-    { commentsBefore :: [LEpaComment]
-    , commentsOnSameLine :: [LEpaComment]
-    , commentsAfter :: [LEpaComment]
-    }
+data NodeComments = NodeComments
+  { commentsBefore :: [LEpaComment]
+  , commentsOnSameLine :: [LEpaComment]
+  , commentsAfter :: [LEpaComment]
+  }
 
 -- | Values indicating whether `do` or `mdo` is used.
 data DoOrMdo

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -138,7 +138,7 @@ pattern HsSigTypeInsideDeclSig x = HsSigType' HsTypeForDeclSig HsTypeNoDir x
 data HsType' = HsType'
   { hsTypeFor :: HsTypeFor -- ^ In which context a `HsType` is located in.
   , hsTypeDir :: HsTypeDir -- ^ How a function signature is printed;
-                             -- either horizontally or vertically.
+                           -- either horizontally or vertically.
   , hsType :: HsType GhcPs -- ^ The actual type.
   }
 

--- a/src/HIndent/Printer.hs
+++ b/src/HIndent/Printer.hs
@@ -20,36 +20,33 @@ import Data.Int (Int64)
 import HIndent.Config
 
 -- | A pretty printing monad.
-newtype Printer a =
-  Printer
-    { runPrinter :: StateT PrintState (MaybeT Identity) a
-    }
-  deriving ( Applicative
-           , Monad
-           , Functor
-           , MonadState PrintState
-           , MonadPlus
-           , Alternative
-           )
+newtype Printer a = Printer
+  { runPrinter :: StateT PrintState (MaybeT Identity) a
+  } deriving ( Applicative
+             , Monad
+             , Functor
+             , MonadState PrintState
+             , MonadPlus
+             , Alternative
+             )
 
 -- | The state of the pretty printer.
-data PrintState =
-  PrintState
-    { psIndentLevel :: !Int64
+data PrintState = PrintState
+  { psIndentLevel :: !Int64
     -- ^ Current indentation level, i.e. every time there's a
     -- new-line, output this many spaces.
-    , psOutput :: !Builder
+  , psOutput :: !Builder
     -- ^ The current output bytestring builder.
-    , psNewline :: !Bool
+  , psNewline :: !Bool
     -- ^ Just outputted a newline?
-    , psColumn :: !Int64
+  , psColumn :: !Int64
     -- ^ Current column.
-    , psLine :: !Int64
+  , psLine :: !Int64
     -- ^ Current line number.
-    , psConfig :: !Config
+  , psConfig :: !Config
     -- ^ Configuration of max colums and indentation style.
-    , psFitOnOneLine :: !Bool
+  , psFitOnOneLine :: !Bool
     -- ^ Bail out if we need to print beyond the current line or
     -- the maximum column.
-    , psEolComment :: !Bool
-    }
+  , psEolComment :: !Bool
+  }

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -108,11 +108,10 @@ shouldBeReadable x y =
   shouldBe (Readable x (Just (diff y x))) (Readable y Nothing)
 
 -- | Prints a string without quoting and escaping.
-data Readable =
-  Readable
-    { readableString :: ByteString
-    , readableDiff :: Maybe String
-    }
+data Readable = Readable
+  { readableString :: ByteString
+  , readableDiff :: Maybe String
+  }
 
 instance Eq Readable where
   (==) = on (==) readableString


### PR DESCRIPTION
After thinking a little, I've decided to specialize the case where a `data` or a `newtype` declaration has only one record constructor. It breaks the consistency, but I don't think people will define multiple record constructors often.

Fixes: #546

@mihaimaruseac By the way, could you merge PRs by [squashing](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests)? It will make the commit log more readable. Of course, I can squash commits by myself, but it'll require force-pushing and I want to avoid it as I may make a mistake. Squashing-merging is easy and handy, I think.