### PR TITLE
Break a long type-level list into multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - A newline is no longer inserted after a pattern signature ([#663]).
 - A type with many type applications are now broken into multiple lines.
   ([#664]).
+- A long type-level list is broken into multiple lines. ([#665]).
 
 ### Removed
 
@@ -305,6 +306,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#665]: https://github.com/mihaimaruseac/hindent/pull/665
 [#664]: https://github.com/mihaimaruseac/hindent/pull/664
 [#663]: https://github.com/mihaimaruseac/hindent/pull/663
 [#662]: https://github.com/mihaimaruseac/hindent/pull/662

--- a/TESTS.md
+++ b/TESTS.md
@@ -1654,24 +1654,6 @@ foo ::
 
 #### Promoted types
 
-Promoted lists
-
-```haskell
-fun1 :: Def ('[ Ref s (Stored Uint32), IBool] T.:-> IBool)
-fun1 = undefined
-
-fun2 :: Def ('[ Ref s (Stored Uint32), IBool] :-> IBool)
-fun2 = undefined
-```
-
-Promoted list (issue #348)
-
-```haskell
-a :: A '[ 'True]
--- nested promoted list with multiple elements.
-b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
-```
-
 Class constraints should leave `::` on same line
 
 ``` haskell
@@ -1706,6 +1688,27 @@ a :: '(T.:->) 'True 'False
 b :: (T.:->) 'True 'False
 c :: '(:->) 'True 'False
 d :: (:->) 'True 'False
+```
+
+##### Promoted lists
+
+Short
+
+```haskell
+fun1 :: Def ('[ Ref s (Stored Uint32), IBool] T.:-> IBool)
+fun1 = undefined
+
+fun2 :: Def ('[ Ref s (Stored Uint32), IBool] :-> IBool)
+fun2 = undefined
+```
+
+Nested
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/348
+a :: A '[ 'True]
+-- nested promoted list with multiple elements.
+b :: A '[ '[ 'True, 'False], '[ 'False, 'True]]
 ```
 
 #### Symbol type constructors

--- a/TESTS.md
+++ b/TESTS.md
@@ -1702,6 +1702,19 @@ fun2 :: Def ('[ Ref s (Stored Uint32), IBool] :-> IBool)
 fun2 = undefined
 ```
 
+Long
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/522
+type OurContext
+  = '[ AuthHandler W.Request (ExtendedPayloadWrapper UserSession)
+     , BasicAuthCheck GameInstanceId
+     , BasicAuthCheck (RegionId, RegionName)
+     , BasicAuthCheck Alert.SourceId
+     , M.MultipartOptions M.Tmp
+     ]
+```
+
 Nested
 
 ```haskell

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1081,7 +1081,7 @@ prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _ -> hPromotedList $ fmap pretty xs
+    _ -> hvPromotedList $ fmap pretty xs
 prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (HsTyLit _ x) = pretty x
 prettyHsType HsWildCardTy {} = string "_"

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -20,7 +20,7 @@ module HIndent.Pretty.Combinators.Lineup
   , -- * Lists
     hList
   , vList
-  , hPromotedList
+  , hvPromotedList
   , -- * Bars
     hvBarSep
   , hBarSep
@@ -135,9 +135,19 @@ hList = brackets . hCommaSep
 vList :: [Printer ()] -> Printer ()
 vList = vCommaSepWrapped ("[", "]")
 
+-- | Runs printers to print a promoted list where elements are aligned in
+-- a line or vertically.
+hvPromotedList :: [Printer ()] -> Printer ()
+hvPromotedList = (<-|>) <$> hPromotedList <*> vPromotedList
+
 -- | Runs printers to construct a promoted list in a line.
 hPromotedList :: [Printer ()] -> Printer ()
 hPromotedList = promotedListBrackets . hCommaSep
+
+-- | Runs printers to construct a promoted list where elements are aligned
+-- vertically.
+vPromotedList :: [Printer ()] -> Printer ()
+vPromotedList = vCommaSepWrapped ("'[", " ]")
 
 -- | Runs printers in a line with a space as the separator.
 spaced :: [Printer ()] -> Printer ()

--- a/src/HIndent/Pretty/Combinators/Lineup.hs
+++ b/src/HIndent/Pretty/Combinators/Lineup.hs
@@ -135,8 +135,8 @@ hList = brackets . hCommaSep
 vList :: [Printer ()] -> Printer ()
 vList = vCommaSepWrapped ("[", "]")
 
--- | Runs printers to print a promoted list where elements are aligned in
--- a line or vertically.
+-- | Runs printers to construct a promoted list where elements are aligned
+-- in a line or vertically.
 hvPromotedList :: [Printer ()] -> Printer ()
 hvPromotedList = (<-|>) <$> hPromotedList <*> vPromotedList
 


### PR DESCRIPTION
Fixes #522
