### PR TITLE
Remove spaces around typed expression brackets

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -2678,7 +2678,7 @@ f =
 Typed quote.
 
 ```haskell
-f = [|| a ||]
+f = [||a||]
 ```
 
 Preserve the trailing newline.

--- a/src/HIndent/Pretty/Combinators/Wrap.hs
+++ b/src/HIndent/Pretty/Combinators/Wrap.hs
@@ -43,9 +43,9 @@ braces = wrap "{" "}"
 brackets :: Printer a -> Printer a
 brackets = wrap "[" "]"
 
--- | Wraps with @[|| @ and @ ||]@.
+-- | Wraps with @[||@ and @||]@.
 typedBrackets :: Printer a -> Printer a
-typedBrackets = wrap "[|| " " ||]"
+typedBrackets = wrap "[||" "||]"
 
 -- | Wraps with double quotes.
 doubleQuotes :: Printer a -> Printer a


### PR DESCRIPTION
To match the formatting of other brackets.

Fixes #638
