### PR TITLE
Fix behaviour with QualifiedDo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- ...
+- Fixed module names being removed from uses of qualified `do` ([#696]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#676]: https://github.com/mihaimaruseac/hindent/pull/676
 [#672]: https://github.com/mihaimaruseac/hindent/pull/672
 [#671]: https://github.com/mihaimaruseac/hindent/pull/671
 [#670]: https://github.com/mihaimaruseac/hindent/pull/670

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,7 +338,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
-[#676]: https://github.com/mihaimaruseac/hindent/pull/676
+[#696]: https://github.com/mihaimaruseac/hindent/pull/696
 [#672]: https://github.com/mihaimaruseac/hindent/pull/672
 [#671]: https://github.com/mihaimaruseac/hindent/pull/671
 [#670]: https://github.com/mihaimaruseac/hindent/pull/670

--- a/TESTS.md
+++ b/TESTS.md
@@ -2299,6 +2299,29 @@ g = mdo
   bar
 ```
 
+#### `QualifiedDo`
+
+Qualified do
+
+```haskell
+{-# LANGUAGE QualifiedDo #-}
+
+f = Module.Path.do
+  a <- foo
+  return a
+```
+
+Qualified do with `mdo`
+
+```haskell
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE QualifiedDo #-}
+
+f = Module.Path.mdo
+  a <- foo
+  return a
+```
+
 ### Function applications
 
 Long line, tuple

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -126,6 +126,12 @@ instance CommentExtraction (HsExpr GhcPs) where
 instance CommentExtraction LambdaCase where
   nodeComments (LambdaCase x _) = nodeComments x
 
+instance CommentExtraction DoOrMdo where
+  nodeComments = const emptyNodeComments
+
+instance CommentExtraction QualifiedDo where
+  nodeComments = const emptyNodeComments
+
 nodeCommentsHsExpr :: HsExpr GhcPs -> NodeComments
 nodeCommentsHsExpr HsVar {} = emptyNodeComments
 nodeCommentsHsExpr (HsUnboundVar x _) = nodeComments x

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -45,6 +45,7 @@ module HIndent.Pretty.Types
   , ListComprehension(..)
   , DoExpression(..)
   , DoOrMdo(..)
+  , QualifiedDo(..)
   , LetIn(..)
   , NodeComments(..)
   , GRHSExprType(..)
@@ -277,7 +278,7 @@ data ListComprehension = ListComprehension
 -- | Use this type to pretty-print a do expression.
 data DoExpression = DoExpression
   { doStmts :: [ExprLStmt GhcPs]
-  , doOrMdo :: DoOrMdo
+  , qualifiedDo :: QualifiedDo
   }
 
 -- | Use this type to pretty-print a @let ... in ...@ expression.
@@ -297,6 +298,11 @@ data NodeComments = NodeComments
 data DoOrMdo
   = Do
   | Mdo
+
+-- | Values indicating whether the `do` is qualified with a module name (and
+-- whether `do` or `mdo` is used)
+data QualifiedDo =
+  QualifiedDo (Maybe ModuleName) DoOrMdo
 
 -- | Values indicating in which context a RHS is located.
 data GRHSExprType


### PR DESCRIPTION
We need to get out the module name from `DoExpr` and `MDoExpr`s and potentially print it (if it is not `Nothing`).

Fixes: #695 