### PR TITLE
Support GHC 9.6

### DIFF
--- a/.github/workflows/presubmit-cabal.yaml
+++ b/.github/workflows/presubmit-cabal.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false # don't cancel other jobs if one fails
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ghc: ["8.10.7", "9.2.5", "9.4.4"]
+        ghc: ["8.10.7", "9.2.5", "9.4.4", "9.6.1"]
     steps:
       - name: "Checkout code"
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support GHC 9.6 ([#699])
+- Support for GHC 9.6 ([#699])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,53 +4,53 @@
 
 ### Added
 
--   Support GHC 9.6 ([#699])
+- Support GHC 9.6 ([#699])
 
 ### Changed
 
--   ...
+- ...
 
 ### Fixed
 
--   Fixed module names being removed from uses of qualified `do` ([#696]).
+- Fixed module names being removed from uses of qualified `do` ([#696]).
 
 ### Removed
 
--   ...
+- ...
 
 ## [6.0.0] - 2023-02-20
 
 ### Added
 
--   The getConfig function is exported.
+- The getConfig function is exported.
 
 ### Changed
 
--   Switched the parser from [`haskell-src-exts`] to [`ghc-lib-parser`].
-    This switch causes changes in the formatting results in some cases.
--   Changed how to format a data type with a record constructor to follow
-    the [Johan Tibell's Haskell Style Guide]. ([#662]).
--   A newline is no longer inserted after a pattern signature ([#663]).
--   A type with many type applications are now broken into multiple lines.
-    ([#664]).
--   A long type-level list is broken into multiple lines. ([#665]).
--   Spaces around typed expression brackets are removed ([#666]).
--   HIndent no longer breaks short class constraints in function signautres into
-    multiple lines ([#669]).
+- Switched the parser from [`haskell-src-exts`] to [`ghc-lib-parser`].
+  This switch causes changes in the formatting results in some cases.
+- Changed how to format a data type with a record constructor to follow
+  the [Johan Tibell's Haskell Style Guide]. ([#662]).
+- A newline is no longer inserted after a pattern signature ([#663]).
+- A type with many type applications are now broken into multiple lines.
+  ([#664]).
+- A long type-level list is broken into multiple lines. ([#665]).
+- Spaces around typed expression brackets are removed ([#666]).
+- HIndent no longer breaks short class constraints in function signautres into
+  multiple lines ([#669]).
 
 ### Fixed
 
--   Fixed the wrong formatting of data family instances inside class instances
-    ([#667]).
--   Fixed the bug of removing the space before the enclosing parenthesis of a
-    record syntax in a signature in a GADT declaration ([#670]).
--   Fixed the bug of inserting unnecessary empty lines if a file contains only
-    comments ([#672]).
+- Fixed the wrong formatting of data family instances inside class instances
+  ([#667]).
+- Fixed the bug of removing the space before the enclosing parenthesis of a
+  record syntax in a signature in a GADT declaration ([#670]).
+- Fixed the bug of inserting unnecessary empty lines if a file contains only
+  comments ([#672]).
 
 ### Removed
 
--   Test functions except `testAst`.
--   Atom support ([#671]).
+- Test functions except `testAst`.
+- Atom support ([#671]).
 
 ## [5.3.4] - 2022-07-07
 
@@ -60,253 +60,253 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Added
 
--   Support for GHC 9.2.2.
--   Test CI with GitHub Actions (WIP).
+- Support for GHC 9.2.2.
+- Test CI with GitHub Actions (WIP).
 
 ### Fixed
 
--   Fixed a broken link to Servant by [@mattfbacon] in [#579].
--   Fixed a build with Cabal 3.6 by [@uhbif19] in [#584].
--   Fixed a compile error for GHC 9.2.2 by [@toku-sa-n] in [#588].
+- Fixed a broken link to Servant by [@mattfbacon] in [#579].
+- Fixed a build with Cabal 3.6 by [@uhbif19] in [#584].
+- Fixed a compile error for GHC 9.2.2 by [@toku-sa-n] in [#588].
 
 ## [5.3.2] - 2022-02-02
 
 ### Fixed
 
--   `MonadFix` issues to support newer GHC versions.
+- `MonadFix` issues to support newer GHC versions.
 
 ## [5.3.1] - 2019-06-28
 
 ### Fixed
 
--   Comment relocations in where clauses of top-level function declarations.
+- Comment relocations in where clauses of top-level function declarations.
 
 ## [5.3.0] - 2019-04-29
 
 ### Added
 
--   Allow batch processing of multiple files.
--   You can now specify default extensions in the configuration file.
+- Allow batch processing of multiple files.
+- You can now specify default extensions in the configuration file.
 
 ### Fixed
 
--   Handle multiple deriving clauses in the `DerivingStrategies` scenario.
--   Ignore non-files in `findCabalFiles`.
--   Prevent HIndent from trying to open non-files when searching for `.cabal` files.
--   Fix the bad output for `[p|Foo|]` pattern quasi-quotes.
--   Fix pretty-printing of `'(:)`.
--   Fix parsing C preprocessor line continuations.
--   Add parentheses around symbols `(:|)` when required.
--   Support `$p` pattern splices.
--   Fix formatting of associated type families.
--   Fix formatting of non-dependent record constructors.
+- Handle multiple deriving clauses in the `DerivingStrategies` scenario.
+- Ignore non-files in `findCabalFiles`.
+- Prevent HIndent from trying to open non-files when searching for `.cabal` files.
+- Fix the bad output for `[p|Foo|]` pattern quasi-quotes.
+- Fix pretty-printing of `'(:)`.
+- Fix parsing C preprocessor line continuations.
+- Add parentheses around symbols `(:|)` when required.
+- Support `$p` pattern splices.
+- Fix formatting of associated type families.
+- Fix formatting of non-dependent record constructors.
 
 ## [5.2.7] - 2019-03-16
 
 ### Fixed
 
--   A bug in the `-X` option
+- A bug in the `-X` option
 
 ## [5.2.6] - 2019-03-16
 
 ### Changed
 
--   Switched to [`optparse-applicative`].
+- Switched to [`optparse-applicative`].
 
 ## [5.2.5] - 2018-01-04
 
 ### Added
 
--   Support getting extensions from a `.cabal` file
+- Support getting extensions from a `.cabal` file
 
 ### Changed
 
--   Improved the indentation with record constructions and updates
--   Updated [`haskell-src-exts`] dependency to version `>= 1.20.0`
+- Improved the indentation with record constructions and updates
+- Updated [`haskell-src-exts`] dependency to version `>= 1.20.0`
 
 ### Fixed
 
--   Fix the `let ... in` bug
--   Fix formatting top-level lambda expressions in `TemplateHaskell` slices
+- Fix the `let ... in` bug
+- Fix formatting top-level lambda expressions in `TemplateHaskell` slices
 
 ## [5.2.4] - 2017-10-20
 
 ### Added
 
--   Improved pretty-printing unboxed tuples.
--   Support the `--validate` option for checking the format without reformatting
--   Support parsing `#include`, `#error`, and `#warning` directives.
--   Support reading `LANGUAGE` pragmas and parse the declared extensions from sources.
--   Support the `EmptyCases` extension
--   Optimize pretty-printing for many functional dependencies.
+- Improved pretty-printing unboxed tuples.
+- Support the `--validate` option for checking the format without reformatting
+- Support parsing `#include`, `#error`, and `#warning` directives.
+- Support reading `LANGUAGE` pragmas and parse the declared extensions from sources.
+- Support the `EmptyCases` extension
+- Optimize pretty-printing for many functional dependencies.
 
 ### Changed
 
--   The `TypeApplications` extension is now disabled-by-default due to the `@` symbol
+- The `TypeApplications` extension is now disabled-by-default due to the `@` symbol
 
 ### Fixed
 
--   Fixed pretty-printing imports
--   Fixed pretty-printing string literals for `DataKinds`
--   Fixed many issues related to infix operators including TH name quotes,
-    `INLINE`/`NOINLINE` pragmas, infix type operators, and infix constructors.
--   Fix extra linebreaks after short identifiers.
+- Fixed pretty-printing imports
+- Fixed pretty-printing string literals for `DataKinds`
+- Fixed many issues related to infix operators including TH name quotes,
+  `INLINE`/`NOINLINE` pragmas, infix type operators, and infix constructors.
+- Fix extra linebreaks after short identifiers.
 
 ## [5.2.3] - 2017-05-07
 
 ### Added
 
--   HIndent now reports where a parse happened.
--   Added `--line-breaks` parameter to support custom line breaks.
--   Added the `RecStmt` support
+- HIndent now reports where a parse happened.
+- Added `--line-breaks` parameter to support custom line breaks.
+- Added the `RecStmt` support
 
 ### Changed
 
--   Explicit import lists are now sorted.
--   Improved pretty-printing long type signatures.
--   Improved pretty-printing GADT records.
--   Improved pretty-printing data declaration records.
--   The `RecursiveDo` and `DoRec` extensions are now disabled-by-default.
+- Explicit import lists are now sorted.
+- Improved pretty-printing long type signatures.
+- Improved pretty-printing GADT records.
+- Improved pretty-printing data declaration records.
+- The `RecursiveDo` and `DoRec` extensions are now disabled-by-default.
 
 ## Fixed
 
--   Fixed pretty-printing for infix data constructors.
--   Fixed pretty-printing of quasi-quoter names.
--   Fixed pretty-printing of complicated type aliases.
--   Fixed pretty-printing of complicated type signatures.
+- Fixed pretty-printing for infix data constructors.
+- Fixed pretty-printing of quasi-quoter names.
+- Fixed pretty-printing of complicated type aliases.
+- Fixed pretty-printing of complicated type signatures.
 
 ## [5.2.2] - 2017-01-16
 
 ### Changed
 
--   HIndent now leaves `do`, lambda (`\x->`), and lambda-case (`\case->`) on the previous line of `$`.
+- HIndent now leaves `do`, lambda (`\x->`), and lambda-case (`\case->`) on the previous line of `$`.
 
 ### Fixed
 
--   Fixed pretty-printing of parallel list comprehensions.
--   Miscellaneous fixes.
+- Fixed pretty-printing of parallel list comprehensions.
+- Miscellaneous fixes.
 
 ## [5.2.1] - 2016-09-01
 
 ### Changed
 
--   The `--tab-size` option is renamed to `--indent-size`.
--   The `PatternSynonyms` extension is now disabled by default.
--   HIndent now puts a newline before the closing bracket on a list.
+- The `--tab-size` option is renamed to `--indent-size`.
+- The `PatternSynonyms` extension is now disabled by default.
+- HIndent now puts a newline before the closing bracket on a list.
 
 ### Fixed
 
--   Fixed handling of paragraph overhang when using large constraints.
--   Fixed pretty-printing of multi-line comments.
--   Fixed bug resulting in adding a spurious space for comments at the end of a file.
--   Fixed bug which results in adding a trailing white space on `<-`
+- Fixed handling of paragraph overhang when using large constraints.
+- Fixed pretty-printing of multi-line comments.
+- Fixed bug resulting in adding a spurious space for comments at the end of a file.
+- Fixed bug which results in adding a trailing white space on `<-`
 
 ## [5.2.0] - 2016-08-30
 
 ### Added
 
--   Support the `.hindent.yaml` file to specify alternative tab width and max
-    column numbers.
--   Implement the tab-size support in Emacs Lisp.
+- Support the `.hindent.yaml` file to specify alternative tab width and max
+  column numbers.
+- Implement the tab-size support in Emacs Lisp.
 
 ### Changed
 
--   The default number of spaces for a tab is changed to 2.
+- The default number of spaces for a tab is changed to 2.
 
 ## [5.1.1] - 2016-08-29
 
 ### Added
 
--   Add shebang support (Fixes [#208]).
--   Output the filename for parse errors (Fixes [#179]).
--   Added a document of the `-X` option (Fixes [#212]).
+- Add shebang support (Fixes [#208]).
+- Output the filename for parse errors (Fixes [#179]).
+- Added a document of the `-X` option (Fixes [#212]).
 
 ### Changed
 
--   HIndent now preserves spaces between groups of imports (Fixes [#200]).
--   HIndent now preserves the last newline if the input ends with one (Fixes [#211]).
--   HIndent now puts the last parenthesis of an export list on a new line (Fixes [#227]).
+- HIndent now preserves spaces between groups of imports (Fixes [#200]).
+- HIndent now preserves the last newline if the input ends with one (Fixes [#211]).
+- HIndent now puts the last parenthesis of an export list on a new line (Fixes [#227]).
 
 ### Fixed
 
--   Fixed pretty-printing explicit `forall`s in instances (Fixes [#218]).
+- Fixed pretty-printing explicit `forall`s in instances (Fixes [#218]).
 
 ## [5.1.0] - 2016-08-25
 
 ### Added
 
--   Add `--tab-size` parameter to control indentation spaces.
+- Add `--tab-size` parameter to control indentation spaces.
 
 ### Changed
 
--   Rewrote comment association for more reliability.
+- Rewrote comment association for more reliability.
 
 ### Fixed
 
--   Some miscellaneous bugs.
+- Some miscellaneous bugs.
 
 ## [5.0.1] - 2016-08-20
 
 ### Added
 
--   Made HIndent compatible with GHC 7.8 through GHC 8.0
--   Added test suites and benchmarks in [`TESTS.md`] and [`BENCHMARKS.md`]
+- Made HIndent compatible with GHC 7.8 through GHC 8.0
+- Added test suites and benchmarks in [`TESTS.md`] and [`BENCHMARKS.md`]
 
 ### Changed
 
--   Re-implement using [`bytestring`] instead of [`text`]
+- Re-implement using [`bytestring`] instead of [`text`]
 
 ## [5.0.0] - 2016-08-11
 
 ### Removed
 
--   Support for styles
+- Support for styles
 
 ## [4.6.4] - 2016-07-15
 
 ### Changed
 
--   The formatted file is now created by coping/deleting a file instead of renaming.
+- The formatted file is now created by coping/deleting a file instead of renaming.
 
 ## [4.6.3] - 2016-04-18
 
 ### Added
 
--   Accept a filename to reformat.
+- Accept a filename to reformat.
 
 ### Fixed
 
--   Fixed the whole module printer.
+- Fixed the whole module printer.
 
 ## [4.5.4] - 2015-06-22
 
 ### Added
 
--   Improvements to Tibell style.
--   6x speed up on rendering operators.
+- Improvements to Tibell style.
+- 6x speed up on rendering operators.
 
 ## [4.4.5] - 2015-11-10
 
 ### Fixed
 
--   Fixed a bug in infix patterns.
+- Fixed a bug in infix patterns.
 
 ## [4.4.2] - 2015-04-05
 
 ### Added
 
--   Support for CPP.
+- Support for CPP.
 
 ### Fixed
 
--   Bunch of Gibiansky style bugs.
--   Tibell style bugs.
+- Bunch of Gibiansky style bugs.
+- Tibell style bugs.
 
 ## [4.3.8] - 2015-02-06
 
 ### Fixed
 
--   A bug in printing operators in statements.
+- A bug in printing operators in statements.
 
 [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v6.0.0...HEAD
 [6.0.0]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...v6.0.0
@@ -333,9 +333,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [4.4.5]: https://github.com/mihaimaruseac/hindent/compare/4.4.4...4.4.5
 [4.4.2]: https://github.com/mihaimaruseac/hindent/compare/4.4.1...4.4.2
 [4.3.8]: https://github.com/mihaimaruseac/hindent/compare/4.3.7...4.3.8
+
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
+
 [#699]: https://github.com/mihaimaruseac/hindent/pull/699
 [#696]: https://github.com/mihaimaruseac/hindent/pull/696
 [#672]: https://github.com/mihaimaruseac/hindent/pull/672
@@ -358,11 +360,14 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [#208]: https://github.com/mihaimaruseac/hindent/pull/208
 [#200]: https://github.com/mihaimaruseac/hindent/pull/200
 [#179]: https://github.com/mihaimaruseac/hindent/pull/179
+
 [`haskell-src-exts`]: https://hackage.haskell.org/package/haskell-src-exts
 [`ghc-lib-parser`]: https://hackage.haskell.org/package/ghc-lib-parser
 [`optparse-applicative`]: https://hackage.haskell.org/package/optparse-applicative
 [`bytestring`]: https://hackage.haskell.org/package/bytestring
 [`text`]: https://hackage.haskell.org/package/text
-[`tests.md`]: TESTS.md
-[`benchmarks.md`]: BENCHMARKS.md
-[johan tibell's haskell style guide]: https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md
+
+[`TESTS.md`]: TESTS.md
+[`BENCHMARKS.md`]: BENCHMARKS.md
+
+[Johan Tibell's Haskell Style Guide]: https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,53 +4,53 @@
 
 ### Added
 
-- ...
+-   Support GHC 9.6 ([#699])
 
 ### Changed
 
-- ...
+-   ...
 
 ### Fixed
 
-- Fixed module names being removed from uses of qualified `do` ([#696]).
+-   Fixed module names being removed from uses of qualified `do` ([#696]).
 
 ### Removed
 
-- ...
+-   ...
 
 ## [6.0.0] - 2023-02-20
 
 ### Added
 
-- The getConfig function is exported.
+-   The getConfig function is exported.
 
 ### Changed
 
-- Switched the parser from [`haskell-src-exts`] to [`ghc-lib-parser`].
-  This switch causes changes in the formatting results in some cases.
-- Changed how to format a data type with a record constructor to follow
-  the [Johan Tibell's Haskell Style Guide]. ([#662]).
-- A newline is no longer inserted after a pattern signature ([#663]).
-- A type with many type applications are now broken into multiple lines.
-  ([#664]).
-- A long type-level list is broken into multiple lines. ([#665]).
-- Spaces around typed expression brackets are removed ([#666]).
-- HIndent no longer breaks short class constraints in function signautres into
-  multiple lines ([#669]).
+-   Switched the parser from [`haskell-src-exts`] to [`ghc-lib-parser`].
+    This switch causes changes in the formatting results in some cases.
+-   Changed how to format a data type with a record constructor to follow
+    the [Johan Tibell's Haskell Style Guide]. ([#662]).
+-   A newline is no longer inserted after a pattern signature ([#663]).
+-   A type with many type applications are now broken into multiple lines.
+    ([#664]).
+-   A long type-level list is broken into multiple lines. ([#665]).
+-   Spaces around typed expression brackets are removed ([#666]).
+-   HIndent no longer breaks short class constraints in function signautres into
+    multiple lines ([#669]).
 
 ### Fixed
 
-- Fixed the wrong formatting of data family instances inside class instances
-  ([#667]).
-- Fixed the bug of removing the space before the enclosing parenthesis of a
-  record syntax in a signature in a GADT declaration ([#670]).
-- Fixed the bug of inserting unnecessary empty lines if a file contains only
-  comments ([#672]).
+-   Fixed the wrong formatting of data family instances inside class instances
+    ([#667]).
+-   Fixed the bug of removing the space before the enclosing parenthesis of a
+    record syntax in a signature in a GADT declaration ([#670]).
+-   Fixed the bug of inserting unnecessary empty lines if a file contains only
+    comments ([#672]).
 
 ### Removed
 
-- Test functions except `testAst`.
-- Atom support ([#671]).
+-   Test functions except `testAst`.
+-   Atom support ([#671]).
 
 ## [5.3.4] - 2022-07-07
 
@@ -60,253 +60,253 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 ### Added
 
-- Support for GHC 9.2.2.
-- Test CI with GitHub Actions (WIP).
+-   Support for GHC 9.2.2.
+-   Test CI with GitHub Actions (WIP).
 
 ### Fixed
 
-- Fixed a broken link to Servant by [@mattfbacon] in [#579].
-- Fixed a build with Cabal 3.6 by [@uhbif19] in [#584].
-- Fixed a compile error for GHC 9.2.2 by [@toku-sa-n] in [#588].
+-   Fixed a broken link to Servant by [@mattfbacon] in [#579].
+-   Fixed a build with Cabal 3.6 by [@uhbif19] in [#584].
+-   Fixed a compile error for GHC 9.2.2 by [@toku-sa-n] in [#588].
 
 ## [5.3.2] - 2022-02-02
 
 ### Fixed
 
-- `MonadFix` issues to support newer GHC versions.
+-   `MonadFix` issues to support newer GHC versions.
 
 ## [5.3.1] - 2019-06-28
 
 ### Fixed
 
-- Comment relocations in where clauses of top-level function declarations.
+-   Comment relocations in where clauses of top-level function declarations.
 
 ## [5.3.0] - 2019-04-29
 
 ### Added
 
-- Allow batch processing of multiple files.
-- You can now specify default extensions in the configuration file.
+-   Allow batch processing of multiple files.
+-   You can now specify default extensions in the configuration file.
 
 ### Fixed
 
-- Handle multiple deriving clauses in the `DerivingStrategies` scenario.
-- Ignore non-files in `findCabalFiles`.
-- Prevent HIndent from trying to open non-files when searching for `.cabal` files.
-- Fix the bad output for `[p|Foo|]` pattern quasi-quotes.
-- Fix pretty-printing of `'(:)`.
-- Fix parsing C preprocessor line continuations.
-- Add parentheses around symbols `(:|)` when required.
-- Support `$p` pattern splices.
-- Fix formatting of associated type families.
-- Fix formatting of non-dependent record constructors.
+-   Handle multiple deriving clauses in the `DerivingStrategies` scenario.
+-   Ignore non-files in `findCabalFiles`.
+-   Prevent HIndent from trying to open non-files when searching for `.cabal` files.
+-   Fix the bad output for `[p|Foo|]` pattern quasi-quotes.
+-   Fix pretty-printing of `'(:)`.
+-   Fix parsing C preprocessor line continuations.
+-   Add parentheses around symbols `(:|)` when required.
+-   Support `$p` pattern splices.
+-   Fix formatting of associated type families.
+-   Fix formatting of non-dependent record constructors.
 
 ## [5.2.7] - 2019-03-16
 
 ### Fixed
 
-- A bug in the `-X` option
+-   A bug in the `-X` option
 
 ## [5.2.6] - 2019-03-16
 
 ### Changed
 
-- Switched to [`optparse-applicative`].
+-   Switched to [`optparse-applicative`].
 
 ## [5.2.5] - 2018-01-04
 
 ### Added
 
-- Support getting extensions from a `.cabal` file
+-   Support getting extensions from a `.cabal` file
 
 ### Changed
 
-- Improved the indentation with record constructions and updates
-- Updated [`haskell-src-exts`] dependency to version `>= 1.20.0`
+-   Improved the indentation with record constructions and updates
+-   Updated [`haskell-src-exts`] dependency to version `>= 1.20.0`
 
 ### Fixed
 
-- Fix the `let ... in` bug
-- Fix formatting top-level lambda expressions in `TemplateHaskell` slices
+-   Fix the `let ... in` bug
+-   Fix formatting top-level lambda expressions in `TemplateHaskell` slices
 
 ## [5.2.4] - 2017-10-20
 
 ### Added
 
-- Improved pretty-printing unboxed tuples.
-- Support the `--validate` option for checking the format without reformatting
-- Support parsing `#include`, `#error`, and `#warning` directives.
-- Support reading `LANGUAGE` pragmas and parse the declared extensions from sources.
-- Support the `EmptyCases` extension
-- Optimize pretty-printing for many functional dependencies.
+-   Improved pretty-printing unboxed tuples.
+-   Support the `--validate` option for checking the format without reformatting
+-   Support parsing `#include`, `#error`, and `#warning` directives.
+-   Support reading `LANGUAGE` pragmas and parse the declared extensions from sources.
+-   Support the `EmptyCases` extension
+-   Optimize pretty-printing for many functional dependencies.
 
 ### Changed
 
-- The `TypeApplications` extension is now disabled-by-default due to the `@` symbol
+-   The `TypeApplications` extension is now disabled-by-default due to the `@` symbol
 
 ### Fixed
 
-- Fixed pretty-printing imports
-- Fixed pretty-printing string literals for `DataKinds`
-- Fixed many issues related to infix operators including TH name quotes,
-  `INLINE`/`NOINLINE` pragmas, infix type operators, and infix constructors.
-- Fix extra linebreaks after short identifiers.
+-   Fixed pretty-printing imports
+-   Fixed pretty-printing string literals for `DataKinds`
+-   Fixed many issues related to infix operators including TH name quotes,
+    `INLINE`/`NOINLINE` pragmas, infix type operators, and infix constructors.
+-   Fix extra linebreaks after short identifiers.
 
 ## [5.2.3] - 2017-05-07
 
 ### Added
 
-- HIndent now reports where a parse happened.
-- Added `--line-breaks` parameter to support custom line breaks.
-- Added the `RecStmt` support
+-   HIndent now reports where a parse happened.
+-   Added `--line-breaks` parameter to support custom line breaks.
+-   Added the `RecStmt` support
 
 ### Changed
 
-- Explicit import lists are now sorted.
-- Improved pretty-printing long type signatures.
-- Improved pretty-printing GADT records.
-- Improved pretty-printing data declaration records.
-- The `RecursiveDo` and `DoRec` extensions are now disabled-by-default.
+-   Explicit import lists are now sorted.
+-   Improved pretty-printing long type signatures.
+-   Improved pretty-printing GADT records.
+-   Improved pretty-printing data declaration records.
+-   The `RecursiveDo` and `DoRec` extensions are now disabled-by-default.
 
 ## Fixed
 
-- Fixed pretty-printing for infix data constructors.
-- Fixed pretty-printing of quasi-quoter names.
-- Fixed pretty-printing of complicated type aliases.
-- Fixed pretty-printing of complicated type signatures.
+-   Fixed pretty-printing for infix data constructors.
+-   Fixed pretty-printing of quasi-quoter names.
+-   Fixed pretty-printing of complicated type aliases.
+-   Fixed pretty-printing of complicated type signatures.
 
 ## [5.2.2] - 2017-01-16
 
 ### Changed
 
-- HIndent now leaves `do`, lambda (`\x->`), and lambda-case (`\case->`) on the previous line of `$`.
+-   HIndent now leaves `do`, lambda (`\x->`), and lambda-case (`\case->`) on the previous line of `$`.
 
 ### Fixed
 
-- Fixed pretty-printing of parallel list comprehensions.
-- Miscellaneous fixes.
+-   Fixed pretty-printing of parallel list comprehensions.
+-   Miscellaneous fixes.
 
 ## [5.2.1] - 2016-09-01
 
 ### Changed
 
-- The `--tab-size` option is renamed to `--indent-size`.
-- The `PatternSynonyms` extension is now disabled by default.
-- HIndent now puts a newline before the closing bracket on a list.
+-   The `--tab-size` option is renamed to `--indent-size`.
+-   The `PatternSynonyms` extension is now disabled by default.
+-   HIndent now puts a newline before the closing bracket on a list.
 
 ### Fixed
 
-- Fixed handling of paragraph overhang when using large constraints.
-- Fixed pretty-printing of multi-line comments.
-- Fixed bug resulting in adding a spurious space for comments at the end of a file.
-- Fixed bug which results in adding a trailing white space on `<-`
+-   Fixed handling of paragraph overhang when using large constraints.
+-   Fixed pretty-printing of multi-line comments.
+-   Fixed bug resulting in adding a spurious space for comments at the end of a file.
+-   Fixed bug which results in adding a trailing white space on `<-`
 
 ## [5.2.0] - 2016-08-30
 
 ### Added
 
-- Support the `.hindent.yaml` file to specify alternative tab width and max
-  column numbers.
-- Implement the tab-size support in Emacs Lisp.
+-   Support the `.hindent.yaml` file to specify alternative tab width and max
+    column numbers.
+-   Implement the tab-size support in Emacs Lisp.
 
 ### Changed
 
-- The default number of spaces for a tab is changed to 2.
+-   The default number of spaces for a tab is changed to 2.
 
 ## [5.1.1] - 2016-08-29
 
 ### Added
 
-- Add shebang support (Fixes [#208]).
-- Output the filename for parse errors (Fixes [#179]).
-- Added a document of the `-X` option (Fixes [#212]).
+-   Add shebang support (Fixes [#208]).
+-   Output the filename for parse errors (Fixes [#179]).
+-   Added a document of the `-X` option (Fixes [#212]).
 
 ### Changed
 
-- HIndent now preserves spaces between groups of imports (Fixes [#200]).
-- HIndent now preserves the last newline if the input ends with one (Fixes [#211]).
-- HIndent now puts the last parenthesis of an export list on a new line (Fixes [#227]).
+-   HIndent now preserves spaces between groups of imports (Fixes [#200]).
+-   HIndent now preserves the last newline if the input ends with one (Fixes [#211]).
+-   HIndent now puts the last parenthesis of an export list on a new line (Fixes [#227]).
 
 ### Fixed
 
-- Fixed pretty-printing explicit `forall`s in instances (Fixes [#218]).
+-   Fixed pretty-printing explicit `forall`s in instances (Fixes [#218]).
 
 ## [5.1.0] - 2016-08-25
 
 ### Added
 
-- Add `--tab-size` parameter to control indentation spaces.
+-   Add `--tab-size` parameter to control indentation spaces.
 
 ### Changed
 
-- Rewrote comment association for more reliability.
+-   Rewrote comment association for more reliability.
 
 ### Fixed
 
-- Some miscellaneous bugs.
+-   Some miscellaneous bugs.
 
 ## [5.0.1] - 2016-08-20
 
 ### Added
 
-- Made HIndent compatible with GHC 7.8 through GHC 8.0
-- Added test suites and benchmarks in [`TESTS.md`] and [`BENCHMARKS.md`]
+-   Made HIndent compatible with GHC 7.8 through GHC 8.0
+-   Added test suites and benchmarks in [`TESTS.md`] and [`BENCHMARKS.md`]
 
 ### Changed
 
-- Re-implement using [`bytestring`] instead of [`text`]
+-   Re-implement using [`bytestring`] instead of [`text`]
 
 ## [5.0.0] - 2016-08-11
 
 ### Removed
 
-- Support for styles
+-   Support for styles
 
 ## [4.6.4] - 2016-07-15
 
 ### Changed
 
-- The formatted file is now created by coping/deleting a file instead of renaming.
+-   The formatted file is now created by coping/deleting a file instead of renaming.
 
 ## [4.6.3] - 2016-04-18
 
 ### Added
 
-- Accept a filename to reformat.
+-   Accept a filename to reformat.
 
 ### Fixed
 
-- Fixed the whole module printer.
+-   Fixed the whole module printer.
 
 ## [4.5.4] - 2015-06-22
 
 ### Added
 
-- Improvements to Tibell style.
-- 6x speed up on rendering operators.
+-   Improvements to Tibell style.
+-   6x speed up on rendering operators.
 
 ## [4.4.5] - 2015-11-10
 
 ### Fixed
 
-- Fixed a bug in infix patterns.
+-   Fixed a bug in infix patterns.
 
 ## [4.4.2] - 2015-04-05
 
 ### Added
 
-- Support for CPP.
+-   Support for CPP.
 
 ### Fixed
 
-- Bunch of Gibiansky style bugs.
-- Tibell style bugs.
+-   Bunch of Gibiansky style bugs.
+-   Tibell style bugs.
 
 ## [4.3.8] - 2015-02-06
 
 ### Fixed
 
-- A bug in printing operators in statements.
+-   A bug in printing operators in statements.
 
 [unreleased]: https://github.com/mihaimaruseac/hindent/compare/v6.0.0...HEAD
 [6.0.0]: https://github.com/mihaimaruseac/hindent/compare/v5.3.4...v6.0.0
@@ -333,11 +333,10 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [4.4.5]: https://github.com/mihaimaruseac/hindent/compare/4.4.4...4.4.5
 [4.4.2]: https://github.com/mihaimaruseac/hindent/compare/4.4.1...4.4.2
 [4.3.8]: https://github.com/mihaimaruseac/hindent/compare/4.3.7...4.3.8
-
 [@mattfbacon]: https://github.com/mattfbacon
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
-
+[#699]: https://github.com/mihaimaruseac/hindent/pull/699
 [#696]: https://github.com/mihaimaruseac/hindent/pull/696
 [#672]: https://github.com/mihaimaruseac/hindent/pull/672
 [#671]: https://github.com/mihaimaruseac/hindent/pull/671
@@ -359,14 +358,11 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [#208]: https://github.com/mihaimaruseac/hindent/pull/208
 [#200]: https://github.com/mihaimaruseac/hindent/pull/200
 [#179]: https://github.com/mihaimaruseac/hindent/pull/179
-
 [`haskell-src-exts`]: https://hackage.haskell.org/package/haskell-src-exts
 [`ghc-lib-parser`]: https://hackage.haskell.org/package/ghc-lib-parser
 [`optparse-applicative`]: https://hackage.haskell.org/package/optparse-applicative
 [`bytestring`]: https://hackage.haskell.org/package/bytestring
 [`text`]: https://hackage.haskell.org/package/text
-
-[`TESTS.md`]: TESTS.md
-[`BENCHMARKS.md`]: BENCHMARKS.md
-
-[Johan Tibell's Haskell Style Guide]: https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md
+[`tests.md`]: TESTS.md
+[`benchmarks.md`]: BENCHMARKS.md
+[johan tibell's haskell style guide]: https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md

--- a/TESTS.md
+++ b/TESTS.md
@@ -40,7 +40,6 @@ main = pure ()
 Empty module
 
 ```haskell
-
 ```
 
 ### Module headers

--- a/TESTS.md
+++ b/TESTS.md
@@ -40,6 +40,7 @@ main = pure ()
 Empty module
 
 ```haskell
+
 ```
 
 ### Module headers
@@ -1182,7 +1183,7 @@ Infix constructor pattern
 
 ```haskell
 -- https://github.com/mihaimaruseac/hindent/issues/424
-from $ \(author `InnerJoin` post) -> pure ()
+a = from $ \(author `InnerJoin` post) -> pure ()
 ```
 
 Unboxed sum pattern matching.
@@ -1634,7 +1635,6 @@ f :: (forall a. Data a => a -> a) -> (forall a b. Data a => a -> b)
 g :: forall a b. a -> b
 ```
 
-
 An infix operator containing `#`
 
 ```haskell
@@ -1671,7 +1671,7 @@ foo ::
 
 Class constraints should leave `::` on same line
 
-``` haskell
+```haskell
 -- see https://github.com/chrisdone/hindent/pull/266#issuecomment-244182805
 fun ::
      (Class a, Class b)
@@ -2005,7 +2005,7 @@ Type application
 ```haskell
 {-# LANGUAGE TypeApplications #-}
 
-fun @Int 12
+a = fun @Int 12
 ```
 
 An expression with a SCC pragma
@@ -2327,32 +2327,33 @@ f = Module.Path.mdo
 Long line, tuple
 
 ```haskell
-test
-  (alphaBetaGamma, deltaEpsilonZeta, etaThetaIota, kappaLambdaMu, nuXiOmicro79)
-  (alphaBetaGamma, deltaEpsilonZeta, etaThetaIota, kappaLambdaMu, nuXiOmicron80)
-  ( alphaBetaGamma
-  , deltaEpsilonZeta
-  , etaThetaIota
-  , kappaLambdaMu
-  , nuXiOmicronP81)
+a =
+  test
+    (alphaBetaGamma, deltaEpsilonZeta, etaThetaIota, kappaLambdaMu, nuXiOmic79)
+    (alphaBetaGamma, deltaEpsilonZeta, etaThetaIota, kappaLambdaMu, nuXiOmicr80)
+    ( alphaBetaGamma
+    , deltaEpsilonZeta
+    , etaThetaIota
+    , kappaLambdaMu
+    , nuXiOmicro81)
 ```
 
 Long line, tuple section
 
 ```haskell
-test
-  (, alphaBetaGamma, , deltaEpsilonZeta, , etaThetaIota, kappaLambdaMu, nu79, )
-  (, alphaBetaGamma, , deltaEpsilonZeta, , etaThetaIota, kappaLambdaMu, , n80, )
-  (
-  , alphaBetaGamma
-  ,
-  , deltaEpsilonZeta
-  ,
-  , etaThetaIota
-  , kappaLambdaMu
-  ,
-  , nu81
-  ,)
+a =
+  test
+    (, alphaBetaGamma, , deltaEpsilonZeta, , etaThetaIota, kappaLambdaMu, nu79)
+    (, alphaBetaGamma, , deltaEpsilonZeta, , etaThetaIota, kappaLambdaMu, nuX80)
+    (
+    , alphaBetaGamma
+    ,
+    , deltaEpsilonZeta
+    ,
+    , etaThetaIota
+    , kappaLambdaMu
+    , nuXi81
+    ,)
 ```
 
 Linebreaks after very short names if the total line length goes over the limit
@@ -2392,9 +2393,10 @@ f = \ !a -> undefined
 An infix operator with a lambda expression
 
 ```haskell
-for xs $ \x -> do
-  left x
-  right x
+a =
+  for xs $ \x -> do
+    left x
+    right x
 ```
 
 Nested lambdas
@@ -2551,16 +2553,18 @@ x =
 With `do`
 
 ```haskell
-for xs $ do
-  left x
-  right x
+a =
+  for xs $ do
+    left x
+    right x
 ```
 
 With lambda-case
 
 ```haskell
-for xs $ \case
-  Left x -> x
+a =
+  for xs $ \case
+    Left x -> x
 ```
 
 `$` chain
@@ -2625,7 +2629,8 @@ Force indent and print RHS in a top-level expression
 
 ```haskell
 -- https://github.com/mihaimaruseac/hindent/issues/473
-template $
+a =
+  template $
   haskell
     [ SomeVeryLongName
     , AnotherLongNameEvenLongToBreakTheLine
@@ -2741,6 +2746,7 @@ f =
   [s|foo
 |]
 ```
+
 ### Ranges
 
 from

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -67,6 +67,8 @@ library
       HIndent.Printer
   other-modules:
       Paths_hindent
+  autogen-modules:
+      Paths_hindent
   hs-source-dirs:
       src
   ghc-options: -Wall -O2
@@ -91,18 +93,24 @@ library
     , unicode-show
     , utf8-string
     , yaml
-  if impl(ghc >= 9.4.1)
-    build-depends:
-        ghc-lib-parser >=9.4.1.20220807 && <9.5
-  else
-    build-depends:
-        ghc-lib-parser >=9.2.3.20220527 && <9.3
   default-language: Haskell2010
+  if impl(ghc >= 9.6.1)
+    build-depends:
+        ghc-lib-parser >=9.6.1.20230312 && <9.7
+  else
+    if impl(ghc >= 9.4.1)
+      build-depends:
+          ghc-lib-parser >=9.4.1.20220807 && <9.5
+    else
+      build-depends:
+          ghc-lib-parser >=9.2.3.20220527 && <9.3
 
 library hindent-internal
   exposed-modules:
       HIndent.Internal.Test.Markdone
   other-modules:
+      Paths_hindent
+  autogen-modules:
       Paths_hindent
   hs-source-dirs:
       internal
@@ -129,13 +137,17 @@ library hindent-internal
     , unicode-show
     , utf8-string
     , yaml
-  if impl(ghc >= 9.4.1)
-    build-depends:
-        ghc-lib-parser >=9.4.1.20220807 && <9.5
-  else
-    build-depends:
-        ghc-lib-parser >=9.2.3.20220527 && <9.3
   default-language: Haskell2010
+  if impl(ghc >= 9.6.1)
+    build-depends:
+        ghc-lib-parser >=9.6.1.20230312 && <9.7
+  else
+    if impl(ghc >= 9.4.1)
+      build-depends:
+          ghc-lib-parser >=9.4.1.20220807 && <9.5
+    else
+      build-depends:
+          ghc-lib-parser >=9.2.3.20220527 && <9.3
 
 executable hindent
   main-is: Main.hs
@@ -169,18 +181,24 @@ executable hindent
     , unicode-show
     , utf8-string
     , yaml
-  if impl(ghc >= 9.4.1)
-    build-depends:
-        ghc-lib-parser >=9.4.1.20220807 && <9.5
-  else
-    build-depends:
-        ghc-lib-parser >=9.2.3.20220527 && <9.3
   default-language: Haskell2010
+  if impl(ghc >= 9.6.1)
+    build-depends:
+        ghc-lib-parser >=9.6.1.20230312 && <9.7
+  else
+    if impl(ghc >= 9.4.1)
+      build-depends:
+          ghc-lib-parser >=9.4.1.20220807 && <9.5
+    else
+      build-depends:
+          ghc-lib-parser >=9.2.3.20220527 && <9.3
 
 test-suite hindent-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Paths_hindent
+  autogen-modules:
       Paths_hindent
   hs-source-dirs:
       tests
@@ -210,18 +228,24 @@ test-suite hindent-test
     , unicode-show
     , utf8-string
     , yaml
-  if impl(ghc >= 9.4.1)
-    build-depends:
-        ghc-lib-parser >=9.4.1.20220807 && <9.5
-  else
-    build-depends:
-        ghc-lib-parser >=9.2.3.20220527 && <9.3
   default-language: Haskell2010
+  if impl(ghc >= 9.6.1)
+    build-depends:
+        ghc-lib-parser >=9.6.1.20230312 && <9.7
+  else
+    if impl(ghc >= 9.4.1)
+      build-depends:
+          ghc-lib-parser >=9.4.1.20220807 && <9.5
+    else
+      build-depends:
+          ghc-lib-parser >=9.2.3.20220527 && <9.3
 
 benchmark hindent-bench
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Paths_hindent
+  autogen-modules:
       Paths_hindent
   hs-source-dirs:
       benchmarks
@@ -251,10 +275,14 @@ benchmark hindent-bench
     , unicode-show
     , utf8-string
     , yaml
-  if impl(ghc >= 9.4.1)
-    build-depends:
-        ghc-lib-parser >=9.4.1.20220807 && <9.5
-  else
-    build-depends:
-        ghc-lib-parser >=9.2.3.20220527 && <9.3
   default-language: Haskell2010
+  if impl(ghc >= 9.6.1)
+    build-depends:
+        ghc-lib-parser >=9.6.1.20230312 && <9.7
+  else
+    if impl(ghc >= 9.4.1)
+      build-depends:
+          ghc-lib-parser >=9.4.1.20220807 && <9.5
+    else
+      build-depends:
+          ghc-lib-parser >=9.2.3.20220527 && <9.3

--- a/package.yaml
+++ b/package.yaml
@@ -47,11 +47,16 @@ dependencies:
   - yaml
 
 when:
-  - condition: impl(ghc >= 9.4.1)
+  - condition: impl(ghc >= 9.6.1)
     then:
-      dependencies: ghc-lib-parser >= 9.4.1.20220807 && < 9.5
+      dependencies: ghc-lib-parser >= 9.6.1.20230312 && < 9.7
     else:
-      dependencies: ghc-lib-parser >= 9.2.3.20220527 && < 9.3
+      when:
+        - condition: impl(ghc >= 9.4.1)
+          then:
+            dependencies: ghc-lib-parser >= 9.4.1.20220807 && < 9.5
+          else:
+            dependencies: ghc-lib-parser >= 9.2.3.20220527 && < 9.3
 
 library:
   source-dirs: src

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -123,10 +123,9 @@ reformat config mexts mfilepath =
                else x' <> "\n")
           (f x)
       | otherwise = f x
-
 -- | Generate an AST from the given module for debugging.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-testAst::ByteString->Either String (HsModule GhcPs)
+testAst :: ByteString -> Either String (HsModule GhcPs)
 #else
 testAst :: ByteString -> Either String HsModule
 #endif
@@ -145,7 +144,6 @@ testAst x =
 -- | Does the strict bytestring have a trailing newline?
 hasTrailingLine :: ByteString -> Bool
 hasTrailingLine xs = not (S8.null xs) && S8.last xs == '\n'
-
 -- | Print the module.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyPrint :: Config -> (HsModule GhcPs) -> Builder

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -124,7 +124,7 @@ reformat config mexts mfilepath =
           (f x)
       | otherwise = f x
 -- | Generate an AST from the given module for debugging.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 testAst :: ByteString -> Either String (HsModule GhcPs)
 #else
 testAst :: ByteString -> Either String HsModule
@@ -145,7 +145,7 @@ testAst x =
 hasTrailingLine :: ByteString -> Bool
 hasTrailingLine xs = not (S8.null xs) && S8.last xs == '\n'
 -- | Print the module.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyPrint :: Config -> (HsModule GhcPs) -> Builder
 #else
 prettyPrint :: Config -> HsModule -> Builder

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -125,7 +125,11 @@ reformat config mexts mfilepath =
       | otherwise = f x
 
 -- | Generate an AST from the given module for debugging.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+testAst::ByteString->Either String (HsModule GhcPs)
+#else
 testAst :: ByteString -> Either String HsModule
+#endif
 testAst x =
   case parseModule Nothing exts (UTF8.toString x) of
     POk _ m -> Right $ modifyASTForPrettyPrinting m
@@ -143,7 +147,11 @@ hasTrailingLine :: ByteString -> Bool
 hasTrailingLine xs = not (S8.null xs) && S8.last xs == '\n'
 
 -- | Print the module.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+prettyPrint :: Config -> (HsModule GhcPs) -> Builder
+#else
 prettyPrint :: Config -> HsModule -> Builder
+#endif
 prettyPrint config m =
   runPrinterStyle config (pretty $ modifyASTForPrettyPrinting m)
 

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -124,7 +124,7 @@ reformat config mexts mfilepath =
           (f x)
       | otherwise = f x
 -- | Generate an AST from the given module for debugging.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 testAst :: ByteString -> Either String (HsModule GhcPs)
 #else
 testAst :: ByteString -> Either String HsModule
@@ -145,7 +145,7 @@ testAst x =
 hasTrailingLine :: ByteString -> Bool
 hasTrailingLine xs = not (S8.null xs) && S8.last xs == '\n'
 -- | Print the module.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 prettyPrint :: Config -> (HsModule GhcPs) -> Builder
 #else
 prettyPrint :: Config -> HsModule -> Builder

--- a/src/HIndent/ModulePreprocessing.hs
+++ b/src/HIndent/ModulePreprocessing.hs
@@ -26,7 +26,11 @@ import Type.Reflection
 --
 -- Pretty-printing a module without calling this function for it before may
 -- raise an error or not print it correctly.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+modifyASTForPrettyPrinting :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 modifyASTForPrettyPrinting :: HsModule -> HsModule
+#endif
 modifyASTForPrettyPrinting m = relocateComments (beforeRelocation m) allComments
   where
     beforeRelocation =
@@ -44,7 +48,11 @@ modifyASTForPrettyPrinting m = relocateComments (beforeRelocation m) allComments
 
 -- | This function modifies the given module AST to apply fixities of infix
 -- operators defined in the 'base' package.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+fixFixities :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 fixFixities :: HsModule -> HsModule
+#endif
 fixFixities = applyFixities baseFixities
 
 -- | This function sets an 'LGRHS's end position to the end position of the
@@ -54,7 +62,11 @@ fixFixities = applyFixities baseFixities
 -- locates comments in the wrong position in the process of comment
 -- relocation. This function prevents it by fixing the 'L?GRHS''s source
 -- span.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+resetLGRHSEndPositionInModule :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 resetLGRHSEndPositionInModule :: HsModule -> HsModule
+#endif
 resetLGRHSEndPositionInModule = everywhere (mkT resetLGRHSEndPosition)
 
 -- | This function sorts lists of statements in order their positions.
@@ -62,7 +74,11 @@ resetLGRHSEndPositionInModule = everywhere (mkT resetLGRHSEndPosition)
 -- For example, the last element of 'HsDo' of 'HsExpr' is the element
 -- before a bar, and the elements are not sorted by their locations. This
 -- function fixes the orderings.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+sortExprLStmt :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 sortExprLStmt :: HsModule -> HsModule
+#endif
 sortExprLStmt m@HsModule {hsmodDecls = xs} = m {hsmodDecls = sorted}
   where
     sorted = everywhere (mkT sortByLoc) xs
@@ -71,12 +87,20 @@ sortExprLStmt m@HsModule {hsmodDecls = xs} = m {hsmodDecls = sorted}
 
 -- | This function removes all comments from the given module not to
 -- duplicate them on comment relocation.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+removeComments :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 removeComments :: HsModule -> HsModule
+#endif
 removeComments = everywhere (mkT $ const emptyComments)
 
 -- | This function replaces all 'EpAnnNotUsed's in 'SrcSpanAnn''s with
 -- 'EpAnn's to make it possible to locate comments on them.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+replaceAllNotUsedAnns :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 replaceAllNotUsedAnns :: HsModule -> HsModule
+#endif
 replaceAllNotUsedAnns = everywhere app
   where
     app ::
@@ -106,7 +130,11 @@ replaceAllNotUsedAnns = everywhere app
 
 -- | This function sets the start column of 'hsmodName' of the given
 -- 'HsModule' to 1 to correctly locate comments above the module name.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+resetModuleNameColumn :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 resetModuleNameColumn :: HsModule -> HsModule
+#endif
 resetModuleNameColumn m@HsModule {hsmodName = Just (L (SrcSpanAnn epa@EpAnn {..} sp) name)} =
   m {hsmodName = Just (L (SrcSpanAnn newAnn sp) name)}
   where
@@ -124,7 +152,11 @@ resetModuleNameColumn m = m
 -- The 'fun_id' contains the function's name. However, 'FunRhs' of 'Match'
 -- also contains the name, and we use the latter one. This function
 -- prevents comments from being located in 'fun_id'.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+closeEpAnnOfFunBindFunId :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 closeEpAnnOfFunBindFunId :: HsModule -> HsModule
+#endif
 closeEpAnnOfFunBindFunId = everywhere (mkT closeEpAnn)
   where
     closeEpAnn :: HsBind GhcPs -> HsBind GhcPs
@@ -138,7 +170,11 @@ closeEpAnnOfFunBindFunId = everywhere (mkT closeEpAnn)
 -- The field contains the annotation of the match LHS. However, the same
 -- information is also stored inside the 'Match'. This function removes the
 -- duplication not to locate comments on a wrong point.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+closeEpAnnOfMatchMExt :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 closeEpAnnOfMatchMExt :: HsModule -> HsModule
+#endif
 closeEpAnnOfMatchMExt = everywhere closeEpAnn
   where
     closeEpAnn ::
@@ -156,7 +192,11 @@ closeEpAnnOfMatchMExt = everywhere closeEpAnn
 --
 -- 'HsFunTy' should not have any comments. Instead, its LHS and RHS should
 -- have them.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+closeEpAnnOfHsFunTy :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 closeEpAnnOfHsFunTy :: HsModule -> HsModule
+#endif
 closeEpAnnOfHsFunTy = everywhere (mkT closeEpAnn)
   where
     closeEpAnn :: HsType GhcPs -> HsType GhcPs
@@ -166,7 +206,11 @@ closeEpAnnOfHsFunTy = everywhere (mkT closeEpAnn)
 -- | This function replaces all 'EpAnn's that contain placeholder anchors
 -- to locate comments correctly. A placeholder anchor is an anchor pointing
 -- on (-1, -1).
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+closePlaceHolderEpAnns :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 closePlaceHolderEpAnns :: HsModule -> HsModule
+#endif
 closePlaceHolderEpAnns = everywhere closeEpAnn
   where
     closeEpAnn ::
@@ -183,7 +227,11 @@ closePlaceHolderEpAnns = everywhere closeEpAnn
 -- | This function removes all 'DocD's from the given module. They have
 -- haddocks, but the same information is stored in 'EpaCommentTok's. Thus,
 -- we need to remove the duplication.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+removeAllDocDs :: (HsModule GhcPs) -> (HsModule GhcPs)
+#else
 removeAllDocDs :: HsModule -> HsModule
+#endif
 removeAllDocDs x@HsModule {hsmodDecls = decls} =
   x {hsmodDecls = filter (not . isDocD . unLoc) decls}
   where

--- a/src/HIndent/ModulePreprocessing.hs
+++ b/src/HIndent/ModulePreprocessing.hs
@@ -25,7 +25,7 @@ import Type.Reflection
 --
 -- Pretty-printing a module without calling this function for it before may
 -- raise an error or not print it correctly.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 modifyASTForPrettyPrinting :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 modifyASTForPrettyPrinting :: HsModule -> HsModule
@@ -46,7 +46,7 @@ modifyASTForPrettyPrinting m = relocateComments (beforeRelocation m) allComments
     isEofComment _ = False
 -- | This function modifies the given module AST to apply fixities of infix
 -- operators defined in the 'base' package.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 fixFixities :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 fixFixities :: HsModule -> HsModule
@@ -59,7 +59,7 @@ fixFixities = applyFixities baseFixities
 -- locates comments in the wrong position in the process of comment
 -- relocation. This function prevents it by fixing the 'L?GRHS''s source
 -- span.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 resetLGRHSEndPositionInModule :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 resetLGRHSEndPositionInModule :: HsModule -> HsModule
@@ -70,7 +70,7 @@ resetLGRHSEndPositionInModule = everywhere (mkT resetLGRHSEndPosition)
 -- For example, the last element of 'HsDo' of 'HsExpr' is the element
 -- before a bar, and the elements are not sorted by their locations. This
 -- function fixes the orderings.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 sortExprLStmt :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 sortExprLStmt :: HsModule -> HsModule
@@ -82,7 +82,7 @@ sortExprLStmt m@HsModule {hsmodDecls = xs} = m {hsmodDecls = sorted}
     sortByLoc = sortBy (compare `on` srcSpanToRealSrcSpan . locA . getLoc)
 -- | This function removes all comments from the given module not to
 -- duplicate them on comment relocation.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 removeComments :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 removeComments :: HsModule -> HsModule
@@ -90,7 +90,7 @@ removeComments :: HsModule -> HsModule
 removeComments = everywhere (mkT $ const emptyComments)
 -- | This function replaces all 'EpAnnNotUsed's in 'SrcSpanAnn''s with
 -- 'EpAnn's to make it possible to locate comments on them.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 replaceAllNotUsedAnns :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 replaceAllNotUsedAnns :: HsModule -> HsModule
@@ -123,7 +123,7 @@ replaceAllNotUsedAnns = everywhere app
     emptyEpaLocation = EpaDelta (SameLine 0) []
 -- | This function sets the start column of 'hsmodName' of the given
 -- 'HsModule' to 1 to correctly locate comments above the module name.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 resetModuleNameColumn :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 resetModuleNameColumn :: HsModule -> HsModule
@@ -144,7 +144,7 @@ resetModuleNameColumn m = m
 -- The 'fun_id' contains the function's name. However, 'FunRhs' of 'Match'
 -- also contains the name, and we use the latter one. This function
 -- prevents comments from being located in 'fun_id'.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 closeEpAnnOfFunBindFunId :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closeEpAnnOfFunBindFunId :: HsModule -> HsModule
@@ -161,7 +161,7 @@ closeEpAnnOfFunBindFunId = everywhere (mkT closeEpAnn)
 -- The field contains the annotation of the match LHS. However, the same
 -- information is also stored inside the 'Match'. This function removes the
 -- duplication not to locate comments on a wrong point.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 closeEpAnnOfMatchMExt :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closeEpAnnOfMatchMExt :: HsModule -> HsModule
@@ -182,7 +182,7 @@ closeEpAnnOfMatchMExt = everywhere closeEpAnn
 --
 -- 'HsFunTy' should not have any comments. Instead, its LHS and RHS should
 -- have them.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 closeEpAnnOfHsFunTy :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closeEpAnnOfHsFunTy :: HsModule -> HsModule
@@ -195,7 +195,7 @@ closeEpAnnOfHsFunTy = everywhere (mkT closeEpAnn)
 -- | This function replaces all 'EpAnn's that contain placeholder anchors
 -- to locate comments correctly. A placeholder anchor is an anchor pointing
 -- on (-1, -1).
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 closePlaceHolderEpAnns :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closePlaceHolderEpAnns :: HsModule -> HsModule
@@ -215,7 +215,7 @@ closePlaceHolderEpAnns = everywhere closeEpAnn
 -- | This function removes all 'DocD's from the given module. They have
 -- haddocks, but the same information is stored in 'EpaCommentTok's. Thus,
 -- we need to remove the duplication.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 removeAllDocDs :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 removeAllDocDs :: HsModule -> HsModule
@@ -232,7 +232,7 @@ removeAllDocDs x@HsModule {hsmodDecls = decls} =
 -- See the documentation of 'resetLGRHSEndPositionInModule' for the reason.
 resetLGRHSEndPosition ::
      LGRHS GhcPs (LHsExpr GhcPs) -> LGRHS GhcPs (LHsExpr GhcPs)
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 resetLGRHSEndPosition (L (SrcSpanAnn locAnn@EpAnn {} sp) (GRHS ext@EpAnn {..} stmt body)) =
   let lastPosition =
         maximum $ realSrcSpanEnd . anchor <$> listify collectAnchor body

--- a/src/HIndent/ModulePreprocessing.hs
+++ b/src/HIndent/ModulePreprocessing.hs
@@ -21,7 +21,6 @@ import Generics.SYB hiding (GT, typeOf, typeRep)
 import HIndent.ModulePreprocessing.CommentRelocation
 import Language.Haskell.GhclibParserEx.Fixity
 import Type.Reflection
-
 -- | This function modifies the given module AST for pretty-printing.
 --
 -- Pretty-printing a module without calling this function for it before may
@@ -45,7 +44,6 @@ modifyASTForPrettyPrinting m = relocateComments (beforeRelocation m) allComments
     allComments = listify (not . isEofComment . ac_tok . unLoc) m
     isEofComment EpaEofComment = True
     isEofComment _ = False
-
 -- | This function modifies the given module AST to apply fixities of infix
 -- operators defined in the 'base' package.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -54,7 +52,6 @@ fixFixities :: (HsModule GhcPs) -> (HsModule GhcPs)
 fixFixities :: HsModule -> HsModule
 #endif
 fixFixities = applyFixities baseFixities
-
 -- | This function sets an 'LGRHS's end position to the end position of the
 -- last RHS in the 'grhssGRHSs'.
 --
@@ -68,7 +65,6 @@ resetLGRHSEndPositionInModule :: (HsModule GhcPs) -> (HsModule GhcPs)
 resetLGRHSEndPositionInModule :: HsModule -> HsModule
 #endif
 resetLGRHSEndPositionInModule = everywhere (mkT resetLGRHSEndPosition)
-
 -- | This function sorts lists of statements in order their positions.
 --
 -- For example, the last element of 'HsDo' of 'HsExpr' is the element
@@ -84,7 +80,6 @@ sortExprLStmt m@HsModule {hsmodDecls = xs} = m {hsmodDecls = sorted}
     sorted = everywhere (mkT sortByLoc) xs
     sortByLoc :: [ExprLStmt GhcPs] -> [ExprLStmt GhcPs]
     sortByLoc = sortBy (compare `on` srcSpanToRealSrcSpan . locA . getLoc)
-
 -- | This function removes all comments from the given module not to
 -- duplicate them on comment relocation.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -93,7 +88,6 @@ removeComments :: (HsModule GhcPs) -> (HsModule GhcPs)
 removeComments :: HsModule -> HsModule
 #endif
 removeComments = everywhere (mkT $ const emptyComments)
-
 -- | This function replaces all 'EpAnnNotUsed's in 'SrcSpanAnn''s with
 -- 'EpAnn's to make it possible to locate comments on them.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -127,7 +121,6 @@ replaceAllNotUsedAnns = everywhere app
     emptyNameAnn = NameAnnTrailing []
     emptyAddEpAnn = AddEpAnn AnnAnyclass emptyEpaLocation
     emptyEpaLocation = EpaDelta (SameLine 0) []
-
 -- | This function sets the start column of 'hsmodName' of the given
 -- 'HsModule' to 1 to correctly locate comments above the module name.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -145,7 +138,6 @@ resetModuleNameColumn m@HsModule {hsmodName = Just (L (SrcSpanAnn epa@EpAnn {..}
         (realSrcSpanEnd anc)
     anc = anchor entry
 resetModuleNameColumn m = m
-
 -- | This function replaces the 'EpAnn' of 'fun_id' in 'FunBind' with
 -- 'EpAnnNotUsed'.
 --
@@ -163,7 +155,6 @@ closeEpAnnOfFunBindFunId = everywhere (mkT closeEpAnn)
     closeEpAnn bind@FunBind {fun_id = (L (SrcSpanAnn _ l) name)} =
       bind {fun_id = L (SrcSpanAnn EpAnnNotUsed l) name}
     closeEpAnn x = x
-
 -- | This function replaces the 'EpAnn' of 'm_ext' in 'Match' with
 -- 'EpAnnNotUsed.
 --
@@ -186,7 +177,6 @@ closeEpAnnOfMatchMExt = everywhere closeEpAnn
       , Just HRefl <- eqTypeRep g (typeRep @Match)
       , Just HRefl <- eqTypeRep h (typeRep @GhcPs) = x {m_ext = EpAnnNotUsed}
       | otherwise = x
-
 -- | This function replaces the 'EpAnn' of the first argument of 'HsFunTy'
 -- of 'HsType'.
 --
@@ -202,7 +192,6 @@ closeEpAnnOfHsFunTy = everywhere (mkT closeEpAnn)
     closeEpAnn :: HsType GhcPs -> HsType GhcPs
     closeEpAnn (HsFunTy _ p l r) = HsFunTy EpAnnNotUsed p l r
     closeEpAnn x = x
-
 -- | This function replaces all 'EpAnn's that contain placeholder anchors
 -- to locate comments correctly. A placeholder anchor is an anchor pointing
 -- on (-1, -1).
@@ -223,7 +212,6 @@ closePlaceHolderEpAnns = everywhere closeEpAnn
       , (EpAnn (Anchor sp _) _ _) <- x
       , srcSpanEndLine sp == -1 && srcSpanEndCol sp == -1 = EpAnnNotUsed
       | otherwise = x
-
 -- | This function removes all 'DocD's from the given module. They have
 -- haddocks, but the same information is stored in 'EpaCommentTok's. Thus,
 -- we need to remove the duplication.

--- a/src/HIndent/ModulePreprocessing.hs
+++ b/src/HIndent/ModulePreprocessing.hs
@@ -25,7 +25,7 @@ import Type.Reflection
 --
 -- Pretty-printing a module without calling this function for it before may
 -- raise an error or not print it correctly.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 modifyASTForPrettyPrinting :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 modifyASTForPrettyPrinting :: HsModule -> HsModule
@@ -46,7 +46,7 @@ modifyASTForPrettyPrinting m = relocateComments (beforeRelocation m) allComments
     isEofComment _ = False
 -- | This function modifies the given module AST to apply fixities of infix
 -- operators defined in the 'base' package.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 fixFixities :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 fixFixities :: HsModule -> HsModule
@@ -59,7 +59,7 @@ fixFixities = applyFixities baseFixities
 -- locates comments in the wrong position in the process of comment
 -- relocation. This function prevents it by fixing the 'L?GRHS''s source
 -- span.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 resetLGRHSEndPositionInModule :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 resetLGRHSEndPositionInModule :: HsModule -> HsModule
@@ -70,7 +70,7 @@ resetLGRHSEndPositionInModule = everywhere (mkT resetLGRHSEndPosition)
 -- For example, the last element of 'HsDo' of 'HsExpr' is the element
 -- before a bar, and the elements are not sorted by their locations. This
 -- function fixes the orderings.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 sortExprLStmt :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 sortExprLStmt :: HsModule -> HsModule
@@ -82,7 +82,7 @@ sortExprLStmt m@HsModule {hsmodDecls = xs} = m {hsmodDecls = sorted}
     sortByLoc = sortBy (compare `on` srcSpanToRealSrcSpan . locA . getLoc)
 -- | This function removes all comments from the given module not to
 -- duplicate them on comment relocation.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 removeComments :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 removeComments :: HsModule -> HsModule
@@ -90,7 +90,7 @@ removeComments :: HsModule -> HsModule
 removeComments = everywhere (mkT $ const emptyComments)
 -- | This function replaces all 'EpAnnNotUsed's in 'SrcSpanAnn''s with
 -- 'EpAnn's to make it possible to locate comments on them.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 replaceAllNotUsedAnns :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 replaceAllNotUsedAnns :: HsModule -> HsModule
@@ -123,7 +123,7 @@ replaceAllNotUsedAnns = everywhere app
     emptyEpaLocation = EpaDelta (SameLine 0) []
 -- | This function sets the start column of 'hsmodName' of the given
 -- 'HsModule' to 1 to correctly locate comments above the module name.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 resetModuleNameColumn :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 resetModuleNameColumn :: HsModule -> HsModule
@@ -144,7 +144,7 @@ resetModuleNameColumn m = m
 -- The 'fun_id' contains the function's name. However, 'FunRhs' of 'Match'
 -- also contains the name, and we use the latter one. This function
 -- prevents comments from being located in 'fun_id'.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 closeEpAnnOfFunBindFunId :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closeEpAnnOfFunBindFunId :: HsModule -> HsModule
@@ -161,7 +161,7 @@ closeEpAnnOfFunBindFunId = everywhere (mkT closeEpAnn)
 -- The field contains the annotation of the match LHS. However, the same
 -- information is also stored inside the 'Match'. This function removes the
 -- duplication not to locate comments on a wrong point.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 closeEpAnnOfMatchMExt :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closeEpAnnOfMatchMExt :: HsModule -> HsModule
@@ -182,7 +182,7 @@ closeEpAnnOfMatchMExt = everywhere closeEpAnn
 --
 -- 'HsFunTy' should not have any comments. Instead, its LHS and RHS should
 -- have them.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 closeEpAnnOfHsFunTy :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closeEpAnnOfHsFunTy :: HsModule -> HsModule
@@ -195,7 +195,7 @@ closeEpAnnOfHsFunTy = everywhere (mkT closeEpAnn)
 -- | This function replaces all 'EpAnn's that contain placeholder anchors
 -- to locate comments correctly. A placeholder anchor is an anchor pointing
 -- on (-1, -1).
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 closePlaceHolderEpAnns :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 closePlaceHolderEpAnns :: HsModule -> HsModule
@@ -215,7 +215,7 @@ closePlaceHolderEpAnns = everywhere closeEpAnn
 -- | This function removes all 'DocD's from the given module. They have
 -- haddocks, but the same information is stored in 'EpaCommentTok's. Thus,
 -- we need to remove the duplication.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 removeAllDocDs :: (HsModule GhcPs) -> (HsModule GhcPs)
 #else
 removeAllDocDs :: HsModule -> HsModule
@@ -232,7 +232,7 @@ removeAllDocDs x@HsModule {hsmodDecls = decls} =
 -- See the documentation of 'resetLGRHSEndPositionInModule' for the reason.
 resetLGRHSEndPosition ::
      LGRHS GhcPs (LHsExpr GhcPs) -> LGRHS GhcPs (LHsExpr GhcPs)
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 resetLGRHSEndPosition (L (SrcSpanAnn locAnn@EpAnn {} sp) (GRHS ext@EpAnn {..} stmt body)) =
   let lastPosition =
         maximum $ realSrcSpanEnd . anchor <$> listify collectAnchor body

--- a/src/HIndent/ModulePreprocessing/CommentRelocation.hs
+++ b/src/HIndent/ModulePreprocessing/CommentRelocation.hs
@@ -63,7 +63,7 @@ data Wrapper =
 type WithComments = State [LEpaComment]
 -- | This function collects all comments from the passed 'HsModule', and
 -- modifies all 'EpAnn's so that all 'EpAnn's have 'EpaCommentsBalanced's.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocateComments :: HsModule GhcPs -> [LEpaComment] -> HsModule GhcPs
 #else
 relocateComments :: HsModule -> [LEpaComment] -> HsModule
@@ -82,7 +82,7 @@ relocateComments = evalState . relocate
       cs <- get
       assert (null cs) (pure x)
 -- | This function locates pragmas to the module's EPA.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocatePragmas :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 relocatePragmas m@HsModule {hsmodExt = xmod@XModulePs {hsmodAnn = epa@EpAnn {}}} = do
   newAnn <- insertComments (isPragma . ac_tok . unLoc) insertPriorComments epa
@@ -96,7 +96,7 @@ relocatePragmas m@HsModule {hsmodAnn = epa@EpAnn {}} = do
 relocatePragmas m = pure m
 -- | This function locates comments that are located before pragmas to the
 -- module's EPA.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocateCommentsBeforePragmas :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 relocateCommentsBeforePragmas m@HsModule {hsmodExt = xmod@XModulePs {hsmodAnn = ann}}
   | pragmaExists m = do
@@ -118,7 +118,7 @@ relocateCommentsBeforePragmas m@HsModule {hsmodAnn = ann}
 
 -- | This function locates comments that are located before each element of
 -- an export list.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocateCommentsInExportList :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsInExportList :: HsModule -> WithComments HsModule
@@ -140,7 +140,7 @@ relocateCommentsInExportList m@HsModule {hsmodExports = Just (L listSp@SrcSpanAn
       realSrcSpanStart (anchor listAnn) < realSrcSpanStart comAnc
 relocateCommentsInExportList x = pure x
 -- | This function locates comments located before top-level declarations.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocateCommentsBeforeTopLevelDecls ::
      HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
@@ -158,7 +158,7 @@ relocateCommentsBeforeTopLevelDecls = everywhereM (applyM f)
 -- | This function scans the given AST from bottom to top and locates
 -- comments that are on the same line as the node.  Comments are stored in
 -- the 'followingComments' of 'EpaCommentsBalanced'.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocateCommentsSameLine :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsSameLine :: HsModule -> WithComments HsModule
@@ -176,7 +176,7 @@ relocateCommentsSameLine = everywhereMEpAnnsBackwards f
       srcSpanStartLine comAnc == srcSpanEndLine anc
 -- | This function locates comments above the top-level declarations in
 -- a 'where' clause in the topmost declaration.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocateCommentsTopLevelWhereClause ::
      HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
@@ -226,7 +226,7 @@ relocateCommentsTopLevelWhereClause m@HsModule {..} = do
       srcSpanEndLine comAnc + 1 == srcSpanStartLine anc
 -- | This function scans the given AST from bottom to top and locates
 -- comments in the comment pool after each node on it.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 relocateCommentsAfter :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsAfter :: HsModule -> WithComments HsModule

--- a/src/HIndent/ModulePreprocessing/CommentRelocation.hs
+++ b/src/HIndent/ModulePreprocessing/CommentRelocation.hs
@@ -63,7 +63,7 @@ data Wrapper =
 type WithComments = State [LEpaComment]
 -- | This function collects all comments from the passed 'HsModule', and
 -- modifies all 'EpAnn's so that all 'EpAnn's have 'EpaCommentsBalanced's.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateComments :: HsModule GhcPs -> [LEpaComment] -> HsModule GhcPs
 #else
 relocateComments :: HsModule -> [LEpaComment] -> HsModule
@@ -82,7 +82,7 @@ relocateComments = evalState . relocate
       cs <- get
       assert (null cs) (pure x)
 -- | This function locates pragmas to the module's EPA.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocatePragmas :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 relocatePragmas m@HsModule {hsmodExt = xmod@XModulePs {hsmodAnn = epa@EpAnn {}}} = do
   newAnn <- insertComments (isPragma . ac_tok . unLoc) insertPriorComments epa
@@ -96,7 +96,7 @@ relocatePragmas m@HsModule {hsmodAnn = epa@EpAnn {}} = do
 relocatePragmas m = pure m
 -- | This function locates comments that are located before pragmas to the
 -- module's EPA.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateCommentsBeforePragmas :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 relocateCommentsBeforePragmas m@HsModule {hsmodExt = xmod@XModulePs {hsmodAnn = ann}}
   | pragmaExists m = do
@@ -118,7 +118,7 @@ relocateCommentsBeforePragmas m@HsModule {hsmodAnn = ann}
 
 -- | This function locates comments that are located before each element of
 -- an export list.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateCommentsInExportList :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsInExportList :: HsModule -> WithComments HsModule
@@ -140,7 +140,7 @@ relocateCommentsInExportList m@HsModule {hsmodExports = Just (L listSp@SrcSpanAn
       realSrcSpanStart (anchor listAnn) < realSrcSpanStart comAnc
 relocateCommentsInExportList x = pure x
 -- | This function locates comments located before top-level declarations.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateCommentsBeforeTopLevelDecls ::
      HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
@@ -158,7 +158,7 @@ relocateCommentsBeforeTopLevelDecls = everywhereM (applyM f)
 -- | This function scans the given AST from bottom to top and locates
 -- comments that are on the same line as the node.  Comments are stored in
 -- the 'followingComments' of 'EpaCommentsBalanced'.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateCommentsSameLine :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsSameLine :: HsModule -> WithComments HsModule
@@ -176,7 +176,7 @@ relocateCommentsSameLine = everywhereMEpAnnsBackwards f
       srcSpanStartLine comAnc == srcSpanEndLine anc
 -- | This function locates comments above the top-level declarations in
 -- a 'where' clause in the topmost declaration.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateCommentsTopLevelWhereClause ::
      HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
@@ -226,7 +226,7 @@ relocateCommentsTopLevelWhereClause m@HsModule {..} = do
       srcSpanEndLine comAnc + 1 == srcSpanStartLine anc
 -- | This function scans the given AST from bottom to top and locates
 -- comments in the comment pool after each node on it.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateCommentsAfter :: HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsAfter :: HsModule -> WithComments HsModule

--- a/src/HIndent/ModulePreprocessing/CommentRelocation.hs
+++ b/src/HIndent/ModulePreprocessing/CommentRelocation.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs,CPP #-}
+{-# LANGUAGE GADTs, CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -53,7 +53,6 @@ import Type.Reflection
 #if MIN_VERSION_GLASGOW_HASKELL(9,6,0,0)
 import Control.Monad
 #endif
-
 -- | A wrapper type used in everywhereMEpAnnsBackwards' to collect all
 -- 'EpAnn's to apply a function with them in order their positions.
 data Wrapper =
@@ -62,7 +61,6 @@ data Wrapper =
 
 -- | 'State' with comments.
 type WithComments = State [LEpaComment]
-
 -- | This function collects all comments from the passed 'HsModule', and
 -- modifies all 'EpAnn's so that all 'EpAnn's have 'EpaCommentsBalanced's.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -83,13 +81,12 @@ relocateComments = evalState . relocate
     assertAllCommentsAreConsumed x = do
       cs <- get
       assert (null cs) (pure x)
-
 -- | This function locates pragmas to the module's EPA.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-relocatePragmas :: HsModule GhcPs -> WithComments (HsModule  GhcPs)
-relocatePragmas m@HsModule {hsmodExt=xmod@XModulePs{hsmodAnn = epa@EpAnn {}}} = do
+relocatePragmas :: HsModule GhcPs -> WithComments (HsModule GhcPs)
+relocatePragmas m@HsModule {hsmodExt = xmod@XModulePs {hsmodAnn = epa@EpAnn {}}} = do
   newAnn <- insertComments (isPragma . ac_tok . unLoc) insertPriorComments epa
-  return m {hsmodExt = xmod{hsmodAnn=newAnn}}
+  return m {hsmodExt = xmod {hsmodAnn = newAnn}}
 #else
 relocatePragmas :: HsModule -> WithComments HsModule
 relocatePragmas m@HsModule {hsmodAnn = epa@EpAnn {}} = do
@@ -97,15 +94,14 @@ relocatePragmas m@HsModule {hsmodAnn = epa@EpAnn {}} = do
   return m {hsmodAnn = newAnn}
 #endif
 relocatePragmas m = pure m
-
 -- | This function locates comments that are located before pragmas to the
 -- module's EPA.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 relocateCommentsBeforePragmas :: HsModule GhcPs -> WithComments (HsModule GhcPs)
-relocateCommentsBeforePragmas m@HsModule {hsmodExt=xmod@XModulePs{hsmodAnn = ann}}
+relocateCommentsBeforePragmas m@HsModule {hsmodExt = xmod@XModulePs {hsmodAnn = ann}}
   | pragmaExists m = do
     newAnn <- insertCommentsByPos (< startPosOfPragmas) insertPriorComments ann
-    pure m {hsmodExt=xmod{hsmodAnn = newAnn}}
+    pure m {hsmodExt = xmod {hsmodAnn = newAnn}}
   | otherwise = pure m
   where
     startPosOfPragmas = anchor $ getLoc $ head $ priorComments $ comments ann
@@ -143,10 +139,10 @@ relocateCommentsInExportList m@HsModule {hsmodExports = Just (L listSp@SrcSpanAn
       srcSpanStartLine comAnc < srcSpanStartLine anc &&
       realSrcSpanStart (anchor listAnn) < realSrcSpanStart comAnc
 relocateCommentsInExportList x = pure x
-
 -- | This function locates comments located before top-level declarations.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-relocateCommentsBeforeTopLevelDecls :: HsModule GhcPs -> WithComments (HsModule GhcPs)
+relocateCommentsBeforeTopLevelDecls ::
+     HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsBeforeTopLevelDecls :: HsModule -> WithComments HsModule
 #endif
@@ -159,7 +155,6 @@ relocateCommentsBeforeTopLevelDecls = everywhereM (applyM f)
       srcSpanStartCol anc == 1 &&
       srcSpanStartCol comAnc == 1 &&
       srcSpanStartLine comAnc < srcSpanStartLine anc
-
 -- | This function scans the given AST from bottom to top and locates
 -- comments that are on the same line as the node.  Comments are stored in
 -- the 'followingComments' of 'EpaCommentsBalanced'.
@@ -179,11 +174,11 @@ relocateCommentsSameLine = everywhereMEpAnnsBackwards f
     isOnSameLine anc comAnc =
       srcSpanStartLine comAnc == srcSpanStartLine anc &&
       srcSpanStartLine comAnc == srcSpanEndLine anc
-
 -- | This function locates comments above the top-level declarations in
 -- a 'where' clause in the topmost declaration.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-relocateCommentsTopLevelWhereClause :: HsModule GhcPs -> WithComments (HsModule GhcPs)
+relocateCommentsTopLevelWhereClause ::
+     HsModule GhcPs -> WithComments (HsModule GhcPs)
 #else
 relocateCommentsTopLevelWhereClause :: HsModule -> WithComments HsModule
 #endif
@@ -229,7 +224,6 @@ relocateCommentsTopLevelWhereClause m@HsModule {..} = do
     isAbove comAnc anc =
       srcSpanStartCol comAnc == srcSpanStartCol anc &&
       srcSpanEndLine comAnc + 1 == srcSpanStartLine anc
-
 -- | This function scans the given AST from bottom to top and locates
 -- comments in the comment pool after each node on it.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)

--- a/src/HIndent/Parse.hs
+++ b/src/HIndent/Parse.hs
@@ -22,8 +22,13 @@ import GHC.Utils.Outputable hiding ((<>), empty, text)
 #endif
 -- | This function parses the given Haskell source code with the given file
 -- path (if any) and parse options.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+parseModule ::
+     Maybe FilePath -> [GLP.Extension] -> String -> ParseResult (HsModule GhcPs)
+#else
 parseModule ::
      Maybe FilePath -> [GLP.Extension] -> String -> ParseResult HsModule
+#endif
 parseModule filepath exts src =
   case unP GLP.parseModule initState of
     POk s m -> POk s $ unLoc m

--- a/src/HIndent/Parse.hs
+++ b/src/HIndent/Parse.hs
@@ -16,13 +16,13 @@ import qualified GHC.Parser as GLP
 import GHC.Parser.Lexer hiding (buffer)
 import GHC.Stack
 import GHC.Types.SrcLoc
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 import GHC.Utils.Error
 import GHC.Utils.Outputable hiding ((<>), empty, text)
 #endif
 -- | This function parses the given Haskell source code with the given file
 -- path (if any) and parse options.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 parseModule ::
      Maybe FilePath -> [GLP.Extension] -> String -> ParseResult (HsModule GhcPs)
 #else
@@ -54,7 +54,7 @@ lexCode code
 -- The 'StarIsType' extension is always enabled to compile a code using
 -- kinds like '* -> *'.
 parserOptsFromExtensions :: [GLP.Extension] -> ParserOpts
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 parserOptsFromExtensions opts =
   mkParserOpts
     opts'

--- a/src/HIndent/Parse.hs
+++ b/src/HIndent/Parse.hs
@@ -16,13 +16,13 @@ import qualified GHC.Parser as GLP
 import GHC.Parser.Lexer hiding (buffer)
 import GHC.Stack
 import GHC.Types.SrcLoc
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 import GHC.Utils.Error
 import GHC.Utils.Outputable hiding ((<>), empty, text)
 #endif
 -- | This function parses the given Haskell source code with the given file
 -- path (if any) and parse options.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 parseModule ::
      Maybe FilePath -> [GLP.Extension] -> String -> ParseResult (HsModule GhcPs)
 #else
@@ -54,7 +54,7 @@ lexCode code
 -- The 'StarIsType' extension is always enabled to compile a code using
 -- kinds like '* -> *'.
 parserOptsFromExtensions :: [GLP.Extension] -> ParserOpts
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 parserOptsFromExtensions opts =
   mkParserOpts
     opts'

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2193,7 +2193,8 @@ instance Pretty (ForeignDecl GhcPs) where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ForeignImport GhcPs) where
-  pretty'=undefined
+  pretty' (CImport (L _ (SourceText s)) conv safety _ _)=spaced [pretty conv, pretty safety, string s]
+  pretty' (CImport _ conv safety _ _)=spaced [pretty conv, pretty safety]
 #else
 instance Pretty ForeignImport where
   pretty' (CImport conv safety _ _ (L _ (SourceText s))) =
@@ -2203,7 +2204,8 @@ instance Pretty ForeignImport where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ForeignExport GhcPs) where
-  pretty'=undefined
+  pretty' (CExport (L _ (SourceText s)) conv)=spaced [pretty conv, string s]
+  pretty' (CExport _ conv)=pretty conv
 #else
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -556,14 +556,14 @@ instance Pretty (HsDataDefn GhcPs) where
         --       newline
         --       -- string "= " |=> vBarSep (fmap pretty dd_cons)
         --       derivingsAfterNewline
-    where
-      isGADT =
-        case dd_cons of
-          (DataTypeCons _ (L _  ConDeclGADT {}:_)) -> True
-          _ -> False
-      derivingsAfterNewline =
-        unless (null dd_derivs) $ newline >> printDerivings
-      printDerivings = lined $ fmap pretty dd_derivs
+    -- where
+    --   isGADT =
+    --     case dd_cons of
+    --       (DataTypeCons _ (L _  ConDeclGADT {}:_)) -> True
+    --       _ -> False
+    --   derivingsAfterNewline =
+    --     unless (null dd_derivs) $ newline >> printDerivings
+    --   printDerivings = lined $ fmap pretty dd_derivs
 #else
 instance Pretty (HsDataDefn GhcPs) where
   pretty' HsDataDefn {..} =
@@ -881,6 +881,10 @@ prettyHsExpr HsBinTick {} = forHpc
 prettyHsExpr (HsBracket _ inner) = pretty inner
 prettyHsExpr HsRnBracketOut {} = notGeneratedByParser
 prettyHsExpr HsTcBracketOut {} = notGeneratedByParser
+#endif
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+prettyHsExpr HsTypedSplice{}=undefined
+prettyHsExpr HsUntypedSplice{}=undefined
 #endif
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -304,7 +304,7 @@ prettyTyClDecl DataDecl {..} = do
   pretty tcdDataDefn
   where
     printDataNewtype =
-      case dd_cons tcdDataDefn of
+      case dd_ND tcdDataDefn of
         DataType -> string "data "
         NewType -> string "newtype "
 #else

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2063,7 +2063,7 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
-instance Pretty (IEWrappedName RdrName) where
+instance Pretty (IEWrappedName GhcPs) where
   pretty' (IEName _ name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
   pretty' (IEType _ name) = string "type " >> pretty name
@@ -2550,7 +2550,10 @@ instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty FieldLabelString where
-  pretty'=output
+  pretty'=undefined
+
+instance Pretty (HsUntypedSplice GhcPs) where
+  pretty'=undefined
 #endif
 
 -- | Marks an AST node as never appearing in an AST.

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -277,7 +277,7 @@ prettyTyClDecl SynDecl {..} = do
   where
     hor = string " = " >> pretty tcdRhs
     ver = newline >> indentedBlock (string "= " |=> pretty tcdRhs)
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
     whenJust (dd_ctxt tcdDataDefn) $ \x -> do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
-#include "macros.h"
+
 -- | Pretty printing.
 --
 -- Some instances define top-level functions to handle CPP.
@@ -49,11 +49,11 @@ import HIndent.Pretty.SigBindFamily
 import HIndent.Pretty.Types
 import HIndent.Printer
 import Text.Show.Unicode
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 import qualified Data.Foldable as NonEmpty
 import GHC.Core.DataCon
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 import GHC.Types.PkgQual
 #endif
 -- | This function pretty-prints the given AST node with comments.
@@ -120,7 +120,7 @@ class CommentExtraction a =>
 -- declarations. Otherwise, extra blank lines will be inserted if only
 -- comments are present in the source code. See
 -- https://github.com/mihaimaruseac/hindent/issues/586#issuecomment-1374992624.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsModule GhcPs) where
   pretty' m@HsModule {hsmodName = Nothing, hsmodImports = [], hsmodDecls = []}
     | not (pragmaExists m) = pure ()
@@ -275,7 +275,7 @@ prettyTyClDecl SynDecl {..} = do
   where
     hor = string " = " >> pretty tcdRhs
     ver = newline >> indentedBlock (string "= " |=> pretty tcdRhs)
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
     whenJust (dd_ctxt tcdDataDefn) $ \x -> do
@@ -387,7 +387,7 @@ prettyHsBind VarBind {} = notGeneratedByParser
 prettyHsBind AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (Sig GhcPs) where
   pretty' (TypeSig _ funName params) = do
     printFunName
@@ -538,7 +538,7 @@ instance Pretty DeclSig where
               pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (DeclSig x) = pretty x
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsDataDefn GhcPs) where
   pretty' HsDataDefn {..} =
     if isGADT
@@ -647,7 +647,7 @@ instance Pretty (HsExpr GhcPs) where
 prettyHsExpr :: HsExpr GhcPs -> Printer ()
 prettyHsExpr (HsVar _ bind) = pretty $ fmap PrefixOp bind
 prettyHsExpr (HsUnboundVar _ x) = pretty x
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsOverLabel _ _ l) = string "#" >> string (unpackFS l)
 #else
 prettyHsExpr (HsOverLabel _ l) = string "#" >> string (unpackFS l)
@@ -656,7 +656,7 @@ prettyHsExpr (HsIPVar _ var) = string "?" >> pretty var
 prettyHsExpr (HsOverLit _ x) = pretty x
 prettyHsExpr (HsLit _ l) = pretty l
 prettyHsExpr (HsLam _ body) = pretty body
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLamCase _ LamCase matches) = pretty $ LambdaCase matches Case
 prettyHsExpr (HsLamCase _ LamCases matches) = pretty $ LambdaCase matches Cases
 #else
@@ -692,7 +692,7 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     insertComments cs (L s@SrcSpanAnn {ann = e@EpAnn {comments = cs'}} r') =
       L (s {ann = e {comments = cs <> cs'}}) r'
     insertComments _ x = x
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsAppType _ l _ r) = do
   pretty l
   string " @"
@@ -705,7 +705,7 @@ prettyHsExpr (HsAppType _ l r) = do
 #endif
 prettyHsExpr (OpApp _ l o r) = pretty (InfixApp l o r False)
 prettyHsExpr (NegApp _ x _) = string "-" >> pretty x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsPar _ _ expr _) = parens $ pretty expr
 #else
 prettyHsExpr (HsPar _ expr) = parens $ pretty expr
@@ -757,7 +757,7 @@ prettyHsExpr (HsIf _ cond t f) = do
 prettyHsExpr (HsMultiIf _ guards) =
   string "if " |=>
   lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
 prettyHsExpr (HsLet _ binds exprs) = pretty $ LetIn binds exprs
@@ -786,7 +786,7 @@ prettyHsExpr (RecordCon _ name fields) = horizontal <-|> vertical
     vertical = do
       pretty name
       (space >> pretty fields) <-|> (newline >> indentedBlock (pretty fields))
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
   where
     hor = spaced [pretty name, either printHorFields printHorFields fields]
@@ -878,7 +878,7 @@ prettyHsExpr (HsProc _ pat body) = hor <-|> ver
       indentedBlock (pretty body)
 prettyHsExpr (HsStatic _ x) = spaced [string "static", pretty x]
 prettyHsExpr (HsPragE _ p x) = spaced [pretty p, pretty x]
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr HsRecSel {} = notGeneratedByParser
 prettyHsExpr (HsTypedBracket _ inner) = typedBrackets $ pretty inner
 prettyHsExpr (HsUntypedBracket _ inner) = pretty inner
@@ -895,7 +895,7 @@ prettyHsExpr (HsBracket _ inner) = pretty inner
 prettyHsExpr HsRnBracketOut {} = notGeneratedByParser
 prettyHsExpr HsTcBracketOut {} = notGeneratedByParser
 #endif
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsTypedSplice _ x) = string "$$" >> pretty x
 prettyHsExpr (HsUntypedSplice _ x) = pretty x
 #endif
@@ -971,7 +971,7 @@ instance Pretty (ConDecl GhcPs) where
   pretty' = prettyConDecl
 
 prettyConDecl :: ConDecl GhcPs -> Printer ()
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyConDecl ConDeclGADT {..} = do
   hCommaSep $ fmap pretty $ NonEmpty.toList con_names
   hor <-|> ver
@@ -1034,7 +1034,7 @@ prettyConDecl ConDeclGADT {..} = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
     noForallCtx = horArgs <-|> verArgs
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
     withForallCtx ctx = do
       pretty con_bndrs
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
@@ -1091,7 +1091,7 @@ prettyConDecl ConDeclGADT {..} = do
         HsOuterImplicit {} -> False
         HsOuterExplicit {} -> True
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
   (do string "forall "
       spaced $ fmap pretty con_ex_tvs
@@ -1138,7 +1138,7 @@ prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
 prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
   mapM_ pretty m_pats
   pretty $ GRHSsExpr GRHSExprCase m_grhss
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyMatchExpr Match {m_ctxt = LamCaseAlt {}, ..} = do
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprCase m_grhss
@@ -1171,7 +1171,7 @@ prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyMatchProc Match {m_ctxt = LamCaseAlt {}, ..} = do
   spaced [mapM_ pretty m_pats, pretty m_grhss]
 #endif
@@ -1303,7 +1303,7 @@ prettyHsType (HsSumTy _ xs) = hvUnboxedSum' $ fmap pretty xs
   -- a type with the same name. However, infix data constructors never
   -- share their names with types because types cannot contain symbols.
   -- Thus there is no ambiguity.
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsType (HsOpTy _ _ l op r) = do
   lineBreak <- gets (configLineBreaks . psConfig)
   if showOutputable op `elem` lineBreak
@@ -1391,7 +1391,7 @@ prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
 prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
 prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
 prettyHsMatchContext PatSyn {} = notGeneratedByParser
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
 #endif
 instance Pretty (ParStmtBlock GhcPs GhcPs) where
@@ -1523,12 +1523,12 @@ prettyPat :: Pat GhcPs -> Printer ()
 prettyPat WildPat {} = string "_"
 prettyPat (VarPat _ x) = pretty x
 prettyPat (LazyPat _ x) = string "~" >> pretty x
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyPat (AsPat _ a _ b) = pretty a >> string "@" >> pretty b
 #else
 prettyPat (AsPat _ a b) = pretty a >> string "@" >> pretty b
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyPat (ParPat _ _ inner _) = parens $ pretty inner
 #else
 prettyPat (ParPat _ inner) = parens $ pretty inner
@@ -1613,7 +1613,7 @@ instance Pretty (HsValBindsLR GhcPs GhcPs) where
 instance Pretty (HsTupArg GhcPs) where
   pretty' (Present _ e) = pretty e
   pretty' Missing {} = pure () -- This appears in a tuple section.
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
     pretty hfbLHS
@@ -1639,7 +1639,7 @@ instance Pretty
       horizontal = space >> pretty hsRecFieldArg
       vertical = newline >> indentedBlock (pretty hsRecFieldArg)
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 -- | For pattern matchings against records.
 instance Pretty
            (HsFieldBind
@@ -1668,7 +1668,7 @@ instance Pretty RecConField where
       string " = "
       pretty hsRecFieldArg
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (FieldOcc GhcPs) where
   pretty' FieldOcc {..} = pretty foLabel
 #else
@@ -1775,7 +1775,7 @@ instance Pretty (FieldLabelStrings GhcPs) where
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
   pretty' (Ambiguous _ name) = pretty name
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
     string "import "
@@ -1813,7 +1813,7 @@ instance Pretty (ImportDecl GhcPs) where
         (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #endif
 packageName :: ImportDecl GhcPs -> Maybe StringLiteral
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 packageName (ideclPkgQual -> RawPkgQual name) = Just name
 packageName _ = Nothing
 #else
@@ -1937,7 +1937,7 @@ instance Pretty PrefixOp where
 instance Pretty Context where
   pretty' (Context xs) =
     pretty (HorizontalContext xs) <-|> pretty (VerticalContext xs)
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty HorizontalContext where
   pretty' (HorizontalContext xs) =
     constraintsParens $ printCommentsAnd xs (hCommaSep . fmap pretty)
@@ -2033,7 +2033,7 @@ instance Pretty
   pretty' (HsValArg x) = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
   pretty' HsArgPar {} = notUsedInParsedStage
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
   pretty' (ExpBr _ x) = brackets $ wrapWithBars $ pretty x
   pretty' (PatBr _ x) = brackets $ string "p" >> wrapWithBars (pretty x)
@@ -2044,7 +2044,7 @@ instance Pretty (HsQuote GhcPs) where
   pretty' (VarBr _ True x) = string "'" >> pretty x
   pretty' (VarBr _ False x) = string "''" >> pretty x
 #endif
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (WarnDecls GhcPs) where
   pretty' (Warnings _ x) = lined $ fmap pretty x
 #else
@@ -2064,12 +2064,12 @@ instance Pretty (WarnDecl GhcPs) where
               [hCommaSep $ fmap pretty names, hCommaSep $ fmap pretty reasons]
           , string " #-}"
           ]
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
   pretty' WithHsDocIdentifiers {..} = pretty hsDocString
 #endif
 
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName GhcPs) where
   pretty' (IEName _ name) = pretty name
@@ -2082,7 +2082,7 @@ instance Pretty (IEWrappedName RdrName) where
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
   pretty' (IEType _ name) = string "type " >> pretty name
 #endif
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
   pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel pretty
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -2095,7 +2095,7 @@ instance Pretty (HsFieldLabel GhcPs) where
 instance Pretty (RuleDecls GhcPs) where
   pretty' HsRules {..} =
     lined $ string "{-# RULES" : fmap pretty rds_rules ++ [string " #-}"]
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (RuleDecl GhcPs) where
   pretty' HsRule {..} =
     spaced
@@ -2189,7 +2189,7 @@ instance Pretty (ForeignDecl GhcPs) where
       , string "::"
       , pretty fd_sig_ty
       ]
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ForeignImport GhcPs) where
   pretty' (CImport (L _ (SourceText s)) conv safety _ _) =
     spaced [pretty conv, pretty safety, string s]
@@ -2201,7 +2201,7 @@ instance Pretty ForeignImport where
   pretty' (CImport conv safety _ _ _) = spaced [pretty conv, pretty safety]
 #endif
 
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
   pretty' (CExport _ conv) = pretty conv
@@ -2217,7 +2217,7 @@ instance Pretty Safety where
   pretty' PlaySafe = string "safe"
   pretty' PlayInterruptible = string "interruptible"
   pretty' PlayRisky = string "unsafe"
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
     spaced [string "{-# ANN", pretty name, pretty expr, string "#-}"]
@@ -2315,7 +2315,7 @@ prettyInlineSpec NoInline {} = string "NOINLINE"
 prettyInlineSpec NoUserInlinePrag =
   error
     "This branch is executed if the inline pragma is not written, but executing this branch means that the pragma is already about to be output, which indicates something goes wrong."
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (HsPatSynDir GhcPs) where
@@ -2365,7 +2365,7 @@ instance Pretty (HsLit GhcPs) where
               newline
               indentedWithSpace (-1) $
                 lined $ fmap (string . dropWhile (/= '\\')) ss
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
 #else
@@ -2374,7 +2374,7 @@ instance Pretty (HsPragE GhcPs) where
 #endif
 instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
   pretty' (HsNumTy _ x) = string $ show x
   pretty' (HsStrTy _ x) = string $ ushow x
@@ -2395,7 +2395,7 @@ instance Pretty (IPBind GhcPs) where
   pretty' = prettyIPBind
 
 prettyIPBind :: IPBind GhcPs -> Printer ()
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyIPBind (IPBind _ l r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #else
@@ -2434,7 +2434,7 @@ prettyHsCmd (HsCmdArrForm _ f _ _ args) =
   bananaBrackets $ spaced $ pretty f : fmap pretty args
 prettyHsCmd (HsCmdApp _ f arg) = spaced [pretty f, pretty arg]
 prettyHsCmd (HsCmdLam _ x) = pretty x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsCmd (HsCmdPar _ _ x _) = parens $ pretty x
 #else
 prettyHsCmd (HsCmdPar _ x) = parens $ pretty x
@@ -2443,7 +2443,7 @@ prettyHsCmd (HsCmdCase _ cond arms) = do
   spaced [string "case", pretty cond, string "of"]
   newline
   indentedBlock $ pretty arms
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsCmd (HsCmdLamCase _ _ arms) = do
   string "\\case"
   newline
@@ -2459,7 +2459,7 @@ prettyHsCmd (HsCmdIf _ _ cond t f) = do
   pretty cond
   newline
   indentedBlock $ lined [string "then " >> pretty t, string "else " >> pretty f]
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsCmd (HsCmdLet _ _ binds _ expr) =
   lined [string "let " |=> pretty binds, string " in " |=> pretty expr]
 #else
@@ -2547,7 +2547,7 @@ instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
     string "forall"
     spacePrefixed $ fmap pretty hso_bndrs
     dot
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty FieldLabelString where
   pretty' = output
 

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2557,7 +2557,7 @@ instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty FieldLabelString where
-  pretty'=undefined
+  pretty'=output
 
 instance Pretty (HsUntypedSplice GhcPs) where
   pretty' (HsUntypedSpliceExpr _ x)=string "$">>pretty x

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -116,7 +116,6 @@ class CommentExtraction a =>
       Pretty a
   where
   pretty' :: a -> Printer ()
-
 -- Do nothing if there are no pragmas, module headers, imports, or
 -- declarations. Otherwise, extra blank lines will be inserted if only
 -- comments are present in the source code. See
@@ -138,7 +137,7 @@ instance Pretty (HsModule GhcPs) where
         error "The module declaration does not exist."
       prettyModuleDecl HsModule { hsmodName = Just name
                                 , hsmodExports = Nothing
-                                , hsmodExt=XModulePs{..}
+                                , hsmodExt = XModulePs {..}
                                 , ..
                                 } = do
         pretty $ fmap ModuleNameWithPrefix name
@@ -148,7 +147,7 @@ instance Pretty (HsModule GhcPs) where
         string " where"
       prettyModuleDecl HsModule { hsmodName = Just name
                                 , hsmodExports = Just exports
-                                , hsmodExt=XModulePs{..}
+                                , hsmodExt = XModulePs {..}
                                 , ..
                                 } = do
         pretty $ fmap ModuleNameWithPrefix name
@@ -236,7 +235,6 @@ instance Pretty HsModule where
           True -> pure $ extractImportsSorted m
           False -> pure $ extractImports m
 #endif
-
 instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
@@ -290,8 +288,8 @@ prettyTyClDecl DataDecl {..} = do
   where
     printDataNewtype =
       case dd_cons tcdDataDefn of
-        DataTypeCons{} -> string "data "
-        NewTypeCon{} -> string "newtype "
+        DataTypeCons {} -> string "data "
+        NewTypeCon {} -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -389,7 +387,6 @@ prettyHsBind VarBind {} = notGeneratedByParser
 prettyHsBind AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (Sig GhcPs) where
   pretty' (TypeSig _ funName params) = do
@@ -520,7 +517,6 @@ instance Pretty (Sig GhcPs) where
       , string "#-}"
       ]
 #endif
-
 instance Pretty DeclSig where
   pretty' (DeclSig (TypeSig _ funName params)) = do
     printFunName
@@ -542,10 +538,9 @@ instance Pretty DeclSig where
               pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (DeclSig x) = pretty x
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsDataDefn GhcPs) where
-  pretty' HsDataDefn {..} = 
+  pretty' HsDataDefn {..} =
     if isGADT
       then do
         whenJust dd_kindSig $ \x -> do
@@ -553,7 +548,7 @@ instance Pretty (HsDataDefn GhcPs) where
           pretty x
         string " where"
         indentedBlock $ newlinePrefixed $ fmap pretty cons
-      else do 
+      else do
         case cons of
           [] -> indentedBlock derivingsAfterNewline
           [x@(L _ ConDeclH98 {con_args = RecCon {}})] -> do
@@ -572,12 +567,13 @@ instance Pretty (HsDataDefn GhcPs) where
               string "= " |=> vBarSep (fmap pretty cons)
               derivingsAfterNewline
     where
-      cons=case dd_cons of
-        NewTypeCon x->[x]
-        DataTypeCons _ xs->xs
+      cons =
+        case dd_cons of
+          NewTypeCon x -> [x]
+          DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
-          (DataTypeCons _ (L _  ConDeclGADT {}:_)) -> True
+          (DataTypeCons _ (L _ ConDeclGADT {}:_)) -> True
           _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
@@ -619,7 +615,6 @@ instance Pretty (HsDataDefn GhcPs) where
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
 #endif
-
 instance Pretty (ClsInstDecl GhcPs) where
   pretty' ClsInstDecl {..} = do
     string "instance " |=> do
@@ -901,8 +896,8 @@ prettyHsExpr HsRnBracketOut {} = notGeneratedByParser
 prettyHsExpr HsTcBracketOut {} = notGeneratedByParser
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-prettyHsExpr (HsTypedSplice _ x) =string "$$">>pretty x
-prettyHsExpr (HsUntypedSplice _ x)=pretty x
+prettyHsExpr (HsTypedSplice _ x) = string "$$" >> pretty x
+prettyHsExpr (HsUntypedSplice _ x) = pretty x
 #endif
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
@@ -1000,18 +995,15 @@ prettyConDecl ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-    
     withCtxOnly ctx =
       (pretty (Context ctx) >> string " => " >> horArgs) <-|>
       (pretty (Context ctx) >> prefixed "=> " verArgs)
-    
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
           inter (string " -> ") $
           fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
@@ -1019,7 +1011,6 @@ prettyConDecl ConDeclGADT {..} = do
           fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-    
     forallNeeded =
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
@@ -1501,7 +1492,6 @@ instance Pretty EpaCommentTok where
 
 instance Pretty (SpliceDecl GhcPs) where
   pretty' (SpliceDecl _ sp _) = pretty sp
-
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsSplice GhcPs) where
   pretty' (HsTypedSplice _ _ _ body) = string "$$" >> pretty body
@@ -1521,7 +1511,6 @@ instance Pretty (HsSplice GhcPs) where
       printers ps s (x:xs) = printers ps (x : s) xs
   pretty' HsSpliced {} = notGeneratedByParser
 #endif
-
 instance Pretty (Pat GhcPs) where
   pretty' = prettyPat
 
@@ -1786,7 +1775,6 @@ instance Pretty (FieldLabelStrings GhcPs) where
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
   pretty' (Ambiguous _ name) = pretty name
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1802,7 +1790,7 @@ instance Pretty (ImportDecl GhcPs) where
       string " as "
       pretty x
     whenJust ideclImportList $ \(x, ps) -> do
-      when (x==EverythingBut) (string " hiding")
+      when (x == EverythingBut) (string " hiding")
       (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
         (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #else
@@ -1824,7 +1812,6 @@ instance Pretty (ImportDecl GhcPs) where
       (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
         (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #endif
-
 packageName :: ImportDecl GhcPs -> Maybe StringLiteral
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 packageName (ideclPkgQual -> RawPkgQual name) = Just name
@@ -2059,12 +2046,11 @@ instance Pretty (HsQuote GhcPs) where
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (WarnDecls GhcPs) where
-  pretty' (Warnings  _ x) = lined $ fmap pretty x
+  pretty' (Warnings _ x) = lined $ fmap pretty x
 #else
 instance Pretty (WarnDecls GhcPs) where
   pretty' (Warnings _ _ x) = lined $ fmap pretty x
 #endif
-
 instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
@@ -2109,12 +2095,11 @@ instance Pretty (HsFieldLabel GhcPs) where
 instance Pretty (RuleDecls GhcPs) where
   pretty' HsRules {..} =
     lined $ string "{-# RULES" : fmap pretty rds_rules ++ [string " #-}"]
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (RuleDecl GhcPs) where
   pretty' HsRule {..} =
     spaced
-      [ printCommentsAnd rd_name (doubleQuotes . string . unpackFS )
+      [ printCommentsAnd rd_name (doubleQuotes . string . unpackFS)
       , lhs
       , string "="
       , pretty rd_rhs
@@ -2149,7 +2134,6 @@ instance Pretty (RuleDecl GhcPs) where
             space
             pretty rd_lhs
 #endif
-
 instance Pretty OccName where
   pretty' = output
 
@@ -2205,11 +2189,11 @@ instance Pretty (ForeignDecl GhcPs) where
       , string "::"
       , pretty fd_sig_ty
       ]
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ForeignImport GhcPs) where
-  pretty' (CImport (L _ (SourceText s)) conv safety _ _)=spaced [pretty conv, pretty safety, string s]
-  pretty' (CImport _ conv safety _ _)=spaced [pretty conv, pretty safety]
+  pretty' (CImport (L _ (SourceText s)) conv safety _ _) =
+    spaced [pretty conv, pretty safety, string s]
+  pretty' (CImport _ conv safety _ _) = spaced [pretty conv, pretty safety]
 #else
 instance Pretty ForeignImport where
   pretty' (CImport conv safety _ _ (L _ (SourceText s))) =
@@ -2219,14 +2203,13 @@ instance Pretty ForeignImport where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ForeignExport GhcPs) where
-  pretty' (CExport (L _ (SourceText s)) conv)=spaced [pretty conv, string s]
-  pretty' (CExport _ conv)=pretty conv
+  pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
+  pretty' (CExport _ conv) = pretty conv
 #else
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
   pretty' (CExport conv _) = pretty conv
 #endif
-
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
@@ -2234,14 +2217,13 @@ instance Pretty Safety where
   pretty' PlaySafe = string "safe"
   pretty' PlayInterruptible = string "interruptible"
   pretty' PlayRisky = string "unsafe"
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
-  pretty' (HsAnnotation  _ (ValueAnnProvenance name) expr) =
+  pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
     spaced [string "{-# ANN", pretty name, pretty expr, string "#-}"]
-  pretty' (HsAnnotation  _ (TypeAnnProvenance name) expr) =
+  pretty' (HsAnnotation _ (TypeAnnProvenance name) expr) =
     spaced [string "{-# ANN type", pretty name, pretty expr, string "#-}"]
-  pretty' (HsAnnotation  _ ModuleAnnProvenance expr) =
+  pretty' (HsAnnotation _ ModuleAnnProvenance expr) =
     spaced [string "{-# ANN module", pretty expr, string "#-}"]
 #else
 instance Pretty (AnnDecl GhcPs) where
@@ -2252,7 +2234,6 @@ instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ _ ModuleAnnProvenance expr) =
     spaced [string "{-# ANN module", pretty expr, string "#-}"]
 #endif
-
 instance Pretty (RoleAnnotDecl GhcPs) where
   pretty' (RoleAnnotDecl _ name roles) =
     spaced $
@@ -2384,18 +2365,15 @@ instance Pretty (HsLit GhcPs) where
               newline
               indentedWithSpace (-1) $
                 lined $ fmap (string . dropWhile (/= '\\')) ss
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
-  pretty' (HsPragSCC  _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
+  pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
 #else
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
 #endif
-
 instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
   pretty' (HsNumTy _ x) = string $ show x
@@ -2407,8 +2385,6 @@ instance Pretty HsTyLit where
   pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #endif
-
-
 instance Pretty (HsPatSigType GhcPs) where
   pretty' HsPS {..} = pretty hsps_body
 
@@ -2571,13 +2547,12 @@ instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
     string "forall"
     spacePrefixed $ fmap pretty hso_bndrs
     dot
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty FieldLabelString where
-  pretty'=output
+  pretty' = output
 
 instance Pretty (HsUntypedSplice GhcPs) where
-  pretty' (HsUntypedSpliceExpr _ x)=string "$">>pretty x
+  pretty' (HsUntypedSpliceExpr _ x) = string "$" >> pretty x
   -- The body of a quasi-quote must not be changed by a formatter.
   -- Changing it will modify the actual behavior of the code.
   --
@@ -2585,15 +2560,16 @@ instance Pretty (HsUntypedSplice GhcPs) where
   pretty' (HsQuasiQuote _ l r) =
     brackets $ do
       pretty l
-      printCommentsAnd r (wrapWithBars .
-        indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
+      printCommentsAnd
+        r
+        (wrapWithBars .
+         indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
         printers (newline : string (reverse s) : ps) "" xs
       printers ps s (x:xs) = printers ps (x : s) xs
 #endif
-
 -- | Marks an AST node as never appearing in an AST.
 --
 -- Some AST node types are only defined in `ghc-lib-parser` and not

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -292,6 +292,21 @@ prettyTyClDecl DataDecl {..} = do
       case dd_cons tcdDataDefn of
         DataTypeCons{} -> string "data "
         NewTypeCon{} -> string "newtype "
+#elif MIN_VERSION_ghc_lib_parser(9,4,1)
+prettyTyClDecl DataDecl {..} = do
+  printDataNewtype |=> do
+    whenJust (dd_ctxt tcdDataDefn) $ \x -> do
+      pretty $ Context x
+      string " =>"
+      newline
+    pretty tcdLName
+  spacePrefixed $ pretty <$> hsq_explicit tcdTyVars
+  pretty tcdDataDefn
+  where
+    printDataNewtype =
+      case dd_cons tcdDataDefn of
+        DataType -> string "data "
+        NewType -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -51,6 +51,7 @@ import HIndent.Printer
 import Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 import qualified Data.Foldable as NonEmpty
+import GHC.Core.DataCon
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 import GHC.Types.PkgQual
@@ -2546,6 +2547,11 @@ instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
     string "forall"
     spacePrefixed $ fmap pretty hso_bndrs
     dot
+
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty FieldLabelString where
+  pretty'=output
+#endif
 
 -- | Marks an AST node as never appearing in an AST.
 --

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -49,6 +49,9 @@ import HIndent.Pretty.SigBindFamily
 import HIndent.Pretty.Types
 import HIndent.Printer
 import Text.Show.Unicode
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+import qualified Data.Foldable as NonEmpty
+#endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 import GHC.Types.PkgQual
 #endif
@@ -117,6 +120,65 @@ class CommentExtraction a =>
 -- declarations. Otherwise, extra blank lines will be inserted if only
 -- comments are present in the source code. See
 -- https://github.com/mihaimaruseac/hindent/issues/586#issuecomment-1374992624.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (HsModule GhcPs) where
+  pretty' m@HsModule {hsmodName = Nothing, hsmodImports = [], hsmodDecls = []}
+    | not (pragmaExists m) = pure ()
+  pretty' m = blanklined printers >> newline
+    where
+      printers = snd <$> filter fst pairs
+      pairs =
+        [ (pragmaExists m, prettyPragmas m)
+        , (moduleDeclExists m, prettyModuleDecl m)
+        , (importsExist m, prettyImports)
+        , (declsExist m, prettyDecls)
+        ]
+      prettyModuleDecl HsModule {hsmodName = Nothing} =
+        error "The module declaration does not exist."
+      prettyModuleDecl HsModule { hsmodName = Just name
+                                , hsmodExports = Nothing
+                                , hsmodExt=XModulePs{..}
+                                , ..
+                                } = do
+        pretty $ fmap ModuleNameWithPrefix name
+        whenJust hsmodDeprecMessage $ \x -> do
+          space
+          pretty $ fmap ModuleDeprecatedPragma x
+        string " where"
+      prettyModuleDecl HsModule { hsmodName = Just name
+                                , hsmodExports = Just exports
+                                , hsmodExt=XModulePs{..}
+                                , ..
+                                } = do
+        pretty $ fmap ModuleNameWithPrefix name
+        whenJust hsmodDeprecMessage $ \x -> do
+          space
+          pretty $ fmap ModuleDeprecatedPragma x
+        newline
+        indentedBlock $ do
+          printCommentsAnd exports (vTuple . fmap pretty)
+          string " where"
+      moduleDeclExists HsModule {hsmodName = Nothing} = False
+      moduleDeclExists _ = True
+      prettyDecls =
+        mapM_ (\(x, sp) -> pretty x >> fromMaybe (return ()) sp) $
+        addDeclSeparator $ hsmodDecls m
+      addDeclSeparator [] = []
+      addDeclSeparator [x] = [(x, Nothing)]
+      addDeclSeparator (x:xs) =
+        (x, Just $ declSeparator $ unLoc x) : addDeclSeparator xs
+      declSeparator (SigD _ TypeSig {}) = newline
+      declSeparator (SigD _ InlineSig {}) = newline
+      declSeparator (SigD _ PatSynSig {}) = newline
+      declSeparator _ = blankline
+      declsExist = not . null . hsmodDecls
+      prettyImports = importDecls >>= blanklined . fmap outputImportGroup
+      outputImportGroup = lined . fmap pretty
+      importDecls =
+        gets (configSortImports . psConfig) >>= \case
+          True -> pure $ extractImportsSorted m
+          False -> pure $ extractImports m
+#else
 instance Pretty HsModule where
   pretty' m@HsModule {hsmodName = Nothing, hsmodImports = [], hsmodDecls = []}
     | not (pragmaExists m) = pure ()
@@ -172,6 +234,7 @@ instance Pretty HsModule where
         gets (configSortImports . psConfig) >>= \case
           True -> pure $ extractImportsSorted m
           False -> pure $ extractImports m
+#endif
 
 instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
@@ -225,9 +288,9 @@ prettyTyClDecl DataDecl {..} = do
   pretty tcdDataDefn
   where
     printDataNewtype =
-      case dd_ND tcdDataDefn of
-        DataType -> string "data "
-        NewType -> string "newtype "
+      case dd_cons tcdDataDefn of
+        DataTypeCons{} -> string "data "
+        NewTypeCon{} -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -311,6 +374,71 @@ prettyHsBind AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (Sig GhcPs) where
+  pretty' (TypeSig _ funName params) = do
+    printFunName
+    string " ::"
+    horizontal <-|> vertical
+    where
+      horizontal = space >> pretty (hswc_body params)
+      vertical = do
+        headLen <- printerLength printFunName
+        indentSpaces <- getIndentSpaces
+        if headLen < indentSpaces
+          then space
+          else newline
+        indentedBlock $
+          indentedWithSpace 3 $
+          pretty $ HsSigTypeInsideVerticalFuncSig <$> hswc_body params
+      printFunName = pretty $ head funName
+  pretty' (PatSynSig _ names sig) =
+    spaced
+      [string "pattern", hCommaSep $ fmap pretty names, string "::", pretty sig]
+  pretty' (ClassOpSig _ True funNames params) =
+    spaced
+      [ string "default"
+      , hCommaSep $ fmap pretty funNames
+      , string "::"
+      , printCommentsAnd params pretty
+      ]
+  pretty' (ClassOpSig _ False funNames params) = do
+    hCommaSep $ fmap pretty funNames
+    string " ::"
+    hor <-|> ver
+    where
+      hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+      ver = do
+        newline
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+  pretty' (FixSig _ x) = pretty x
+  pretty' (InlineSig _ name detail) =
+    spaced [string "{-#", pretty detail, pretty name, string "#-}"]
+  pretty' (SpecSig _ name sig _) =
+    spaced
+      [ string "{-# SPECIALISE"
+      , pretty name
+      , string "::"
+      , pretty $ head sig
+      , string "#-}"
+      ]
+  pretty' (SpecInstSig _ sig) =
+    spaced [string "{-# SPECIALISE instance", pretty sig, string "#-}"]
+  pretty' (MinimalSig _ xs) =
+    string "{-# MINIMAL " |=> do
+      pretty xs
+      string " #-}"
+  pretty' (SCCFunSig _ name _) =
+    spaced [string "{-# SCC", pretty name, string "#-}"]
+  pretty' (CompleteMatchSig _ names _) =
+    spaced
+      [ string "{-# COMPLETE"
+      , printCommentsAnd names (hCommaSep . fmap pretty)
+      , string "#-}"
+      ]
+#else
 instance Pretty (Sig GhcPs) where
   pretty' (TypeSig _ funName params) = do
     printFunName
@@ -375,6 +503,7 @@ instance Pretty (Sig GhcPs) where
       , printCommentsAnd names (hCommaSep . fmap pretty)
       , string "#-}"
       ]
+#endif
 
 instance Pretty DeclSig where
   pretty' (DeclSig (TypeSig _ funName params)) = do
@@ -398,6 +527,43 @@ instance Pretty DeclSig where
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (DeclSig x) = pretty x
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (HsDataDefn GhcPs) where
+  pretty' HsDataDefn {..} = undefined
+    -- if isGADT
+    --   then do
+    --     whenJust dd_kindSig $ \x -> do
+    --       string " :: "
+    --       pretty x
+    --     string " where"
+    --     indentedBlock $ newlinePrefixed $ fmap pretty dd_cons
+    --   else do undefined
+        -- case dd_cons of
+        --   [] -> indentedBlock derivingsAfterNewline
+        --   [x@(L _ ConDeclH98 {con_args = RecCon {}})] -> do
+        --     string " = "
+        --     pretty x
+        --     unless (null dd_derivs) $ space |=> printDerivings
+        --   [x] -> do
+        --     string " ="
+        --     newline
+        --     indentedBlock $ do
+        --       pretty x
+        --       derivingsAfterNewline
+        --   _ ->
+        --     indentedBlock $ do
+        --       newline
+        --       -- string "= " |=> vBarSep (fmap pretty dd_cons)
+        --       derivingsAfterNewline
+    where
+      isGADT =
+        case dd_cons of
+          (DataTypeCons _ (L _  ConDeclGADT {}:_)) -> True
+          _ -> False
+      derivingsAfterNewline =
+        unless (null dd_derivs) $ newline >> printDerivings
+      printDerivings = lined $ fmap pretty dd_derivs
+#else
 instance Pretty (HsDataDefn GhcPs) where
   pretty' HsDataDefn {..} =
     if isGADT
@@ -433,6 +599,7 @@ instance Pretty (HsDataDefn GhcPs) where
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
+#endif
 
 instance Pretty (ClsInstDecl GhcPs) where
   pretty' ClsInstDecl {..} = do
@@ -466,7 +633,11 @@ instance Pretty (HsExpr GhcPs) where
 prettyHsExpr :: HsExpr GhcPs -> Printer ()
 prettyHsExpr (HsVar _ bind) = pretty $ fmap PrefixOp bind
 prettyHsExpr (HsUnboundVar _ x) = pretty x
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+prettyHsExpr (HsOverLabel _ _ l) = string "#" >> string (unpackFS l)
+#else
 prettyHsExpr (HsOverLabel _ l) = string "#" >> string (unpackFS l)
+#endif
 prettyHsExpr (HsIPVar _ var) = string "?" >> pretty var
 prettyHsExpr (HsOverLit _ x) = pretty x
 prettyHsExpr (HsLit _ l) = pretty l
@@ -507,10 +678,17 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     insertComments cs (L s@SrcSpanAnn {ann = e@EpAnn {comments = cs'}} r') =
       L (s {ann = e {comments = cs <> cs'}}) r'
     insertComments _ x = x
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+prettyHsExpr (HsAppType _ l _ r) = do
+  pretty l
+  string " @"
+  pretty r
+#else
 prettyHsExpr (HsAppType _ l r) = do
   pretty l
   string " @"
   pretty r
+#endif
 prettyHsExpr (OpApp _ l o r) = pretty (InfixApp l o r False)
 prettyHsExpr (NegApp _ x _) = string "-" >> pretty x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -669,7 +847,9 @@ prettyHsExpr (ExprWithTySig _ e sig) = do
   string " :: "
   pretty $ hswc_body sig
 prettyHsExpr (ArithSeq _ _ x) = pretty x
+#if !MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyHsExpr (HsSpliceE _ x) = pretty x
+#endif
 prettyHsExpr (HsProc _ pat x@(L _ (HsCmdTop _ (L _ (HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
@@ -773,6 +953,55 @@ instance Pretty (ConDecl GhcPs) where
   pretty' = prettyConDecl
 
 prettyConDecl :: ConDecl GhcPs -> Printer ()
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+prettyConDecl ConDeclGADT {..} = do
+  hCommaSep $ fmap pretty $ NonEmpty.toList con_names
+  hor <-|> ver
+  where
+    hor = string " :: " |=> body
+    ver = do
+      newline
+      indentedBlock (string ":: " |=> body)
+    body =
+      case (forallNeeded, con_mb_cxt) of
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
+        (False, Just ctx) -> withCtxOnly ctx
+        (False, Nothing) -> noForallCtx
+    withForallOnly = do
+      pretty con_bndrs
+      (space >> horArgs) <-|> (newline >> verArgs)
+    noForallCtx = horArgs <-|> verArgs
+    withForallCtx ctx = do
+      pretty con_bndrs
+      (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
+      newline
+      prefixed "=> " verArgs
+    
+    withCtxOnly ctx =
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
+    
+    horArgs =
+      case con_g_args of
+        PrefixConGADT xs ->
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+        RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
+    
+    verArgs =
+      case con_g_args of
+        PrefixConGADT xs ->
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+        RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
+    recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
+    
+    forallNeeded =
+      case unLoc con_bndrs of
+        HsOuterImplicit {} -> False
+        HsOuterExplicit {} -> True
+#else
 prettyConDecl ConDeclGADT {..} = do
   hCommaSep $ fmap pretty con_names
   hor <-|> ver
@@ -847,6 +1076,7 @@ prettyConDecl ConDeclGADT {..} = do
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
         HsOuterExplicit {} -> True
+#endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
   (do string "forall "
@@ -1249,6 +1479,7 @@ instance Pretty EpaCommentTok where
 instance Pretty (SpliceDecl GhcPs) where
   pretty' (SpliceDecl _ sp _) = pretty sp
 
+#if !MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsSplice GhcPs) where
   pretty' (HsTypedSplice _ _ _ body) = string "$$" >> pretty body
   pretty' (HsUntypedSplice _ DollarSplice _ body) = string "$" >> pretty body
@@ -1266,6 +1497,7 @@ instance Pretty (HsSplice GhcPs) where
         printers (newline : string (reverse s) : ps) "" xs
       printers ps s (x:xs) = printers ps (x : s) xs
   pretty' HsSpliced {} = notGeneratedByParser
+#endif
 
 instance Pretty (Pat GhcPs) where
   pretty' = prettyPat
@@ -1279,7 +1511,11 @@ prettyPat :: Pat GhcPs -> Printer ()
 prettyPat WildPat {} = string "_"
 prettyPat (VarPat _ x) = pretty x
 prettyPat (LazyPat _ x) = string "~" >> pretty x
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+prettyPat (AsPat _ a _ b) = pretty a >> string "@" >> pretty b
+#else
 prettyPat (AsPat _ a b) = pretty a >> string "@" >> pretty b
+#endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyPat (ParPat _ _ inner _) = parens $ pretty inner
 #else
@@ -1528,6 +1764,25 @@ instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
   pretty' (Ambiguous _ name) = pretty name
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (ImportDecl GhcPs) where
+  pretty' decl@ImportDecl {..} = do
+    string "import "
+    when (ideclSource == IsBoot) $ string "{-# SOURCE #-} "
+    when ideclSafe $ string "safe "
+    unless (ideclQualified == NotQualified) $ string "qualified "
+    whenJust (packageName decl) $ \x -> do
+      pretty x
+      space
+    pretty ideclName
+    whenJust ideclAs $ \x -> do
+      string " as "
+      pretty x
+    whenJust ideclImportList $ \(x, ps) -> do
+      when (x==EverythingBut) (string " hiding")
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
+        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+#else
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
     string "import "
@@ -1545,6 +1800,7 @@ instance Pretty (ImportDecl GhcPs) where
       when x (string " hiding")
       (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
         (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+#endif
 
 packageName :: ImportDecl GhcPs -> Maybe StringLiteral
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -1778,8 +2034,13 @@ instance Pretty (HsQuote GhcPs) where
   pretty' (VarBr _ True x) = string "'" >> pretty x
   pretty' (VarBr _ False x) = string "''" >> pretty x
 #endif
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (WarnDecls GhcPs) where
+  pretty' (Warnings  _ x) = lined $ fmap pretty x
+#else
 instance Pretty (WarnDecls GhcPs) where
   pretty' (Warnings _ _ x) = lined $ fmap pretty x
+#endif
 
 instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
@@ -1798,12 +2059,24 @@ instance Pretty (WarnDecl GhcPs) where
 instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
   pretty' WithHsDocIdentifiers {..} = pretty hsDocString
 #endif
+
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+-- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
+instance Pretty (IEWrappedName RdrName) where
+  pretty' (IEName _ name) = pretty name
+  pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
+  pretty' (IEType _ name) = string "type " >> pretty name
+#else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName RdrName) where
   pretty' (IEName name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
   pretty' (IEType _ name) = string "type " >> pretty name
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#endif
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (DotFieldOcc GhcPs) where
+  pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel pretty
+#elif MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (DotFieldOcc GhcPs) where
   pretty' DotFieldOcc {..} = printCommentsAnd dfoLabel (string . unpackFS)
 #else
@@ -1814,6 +2087,26 @@ instance Pretty (RuleDecls GhcPs) where
   pretty' HsRules {..} =
     lined $ string "{-# RULES" : fmap pretty rds_rules ++ [string " #-}"]
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (RuleDecl GhcPs) where
+  pretty' HsRule {..} =
+    spaced
+      [ printCommentsAnd rd_name (doubleQuotes . string . unpackFS )
+      , lhs
+      , string "="
+      , pretty rd_rhs
+      ]
+    where
+      lhs =
+        if null rd_tmvs
+          then pretty rd_lhs
+          else do
+            string "forall "
+            spaced $ fmap pretty rd_tmvs
+            dot
+            space
+            pretty rd_lhs
+#else
 instance Pretty (RuleDecl GhcPs) where
   pretty' HsRule {..} =
     spaced
@@ -1832,6 +2125,7 @@ instance Pretty (RuleDecl GhcPs) where
             dot
             space
             pretty rd_lhs
+#endif
 
 instance Pretty OccName where
   pretty' = output
@@ -1889,14 +2183,24 @@ instance Pretty (ForeignDecl GhcPs) where
       , pretty fd_sig_ty
       ]
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (ForeignImport GhcPs) where
+  pretty'=undefined
+#else
 instance Pretty ForeignImport where
   pretty' (CImport conv safety _ _ (L _ (SourceText s))) =
     spaced [pretty conv, pretty safety, string s]
   pretty' (CImport conv safety _ _ _) = spaced [pretty conv, pretty safety]
+#endif
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (ForeignExport GhcPs) where
+  pretty'=undefined
+#else
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
   pretty' (CExport conv _) = pretty conv
+#endif
 
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
@@ -1906,6 +2210,15 @@ instance Pretty Safety where
   pretty' PlayInterruptible = string "interruptible"
   pretty' PlayRisky = string "unsafe"
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (AnnDecl GhcPs) where
+  pretty' (HsAnnotation  _ (ValueAnnProvenance name) expr) =
+    spaced [string "{-# ANN", pretty name, pretty expr, string "#-}"]
+  pretty' (HsAnnotation  _ (TypeAnnProvenance name) expr) =
+    spaced [string "{-# ANN type", pretty name, pretty expr, string "#-}"]
+  pretty' (HsAnnotation  _ ModuleAnnProvenance expr) =
+    spaced [string "{-# ANN module", pretty expr, string "#-}"]
+#else
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ _ (ValueAnnProvenance name) expr) =
     spaced [string "{-# ANN", pretty name, pretty expr, string "#-}"]
@@ -1913,6 +2226,7 @@ instance Pretty (AnnDecl GhcPs) where
     spaced [string "{-# ANN type", pretty name, pretty expr, string "#-}"]
   pretty' (HsAnnotation _ _ ModuleAnnProvenance expr) =
     spaced [string "{-# ANN module", pretty expr, string "#-}"]
+#endif
 
 instance Pretty (RoleAnnotDecl GhcPs) where
   pretty' (RoleAnnotDecl _ name roles) =
@@ -2046,16 +2360,29 @@ instance Pretty (HsLit GhcPs) where
               indentedWithSpace (-1) $
                 lined $ fmap (string . dropWhile (/= '\\')) ss
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (HsPragE GhcPs) where
+  pretty' (HsPragSCC  _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
+#else
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
+#endif
 
 instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
 
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance Pretty (HsTyLit GhcPs) where
+  pretty' (HsNumTy _ x) = string $ show x
+  pretty' (HsStrTy _ x) = string $ ushow x
+  pretty' (HsCharTy _ x) = string $ show x
+#else
 instance Pretty HsTyLit where
   pretty' (HsNumTy _ x) = string $ show x
   pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
+#endif
+
 
 instance Pretty (HsPatSigType GhcPs) where
   pretty' HsPS {..} = pretty hsps_body

--- a/src/HIndent/Pretty/Combinators/Outputable.hs
+++ b/src/HIndent/Pretty/Combinators/Outputable.hs
@@ -35,7 +35,7 @@ showOutputable = showPpr dynFlags
 
 -- | 'DynFlags' for calling 'showPpr'
 dynFlags :: DynFlags
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 dynFlags = defaultDynFlags fakeSettings
 #else
 dynFlags = defaultDynFlags fakeSettings fakeLlvmConfig

--- a/src/HIndent/Pretty/Combinators/Outputable.hs
+++ b/src/HIndent/Pretty/Combinators/Outputable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Printer combinators for printing values of types implementing
 -- 'Outputable'.
 module HIndent.Pretty.Combinators.Outputable
@@ -33,4 +34,8 @@ showOutputable = showPpr dynFlags
 
 -- | 'DynFlags' for calling 'showPpr'
 dynFlags :: DynFlags
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+dynFlags = defaultDynFlags fakeSettings 
+#else
 dynFlags = defaultDynFlags fakeSettings fakeLlvmConfig
+#endif

--- a/src/HIndent/Pretty/Combinators/Outputable.hs
+++ b/src/HIndent/Pretty/Combinators/Outputable.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Printer combinators for printing values of types implementing
 -- 'Outputable'.
 module HIndent.Pretty.Combinators.Outputable
@@ -35,7 +36,7 @@ showOutputable = showPpr dynFlags
 -- | 'DynFlags' for calling 'showPpr'
 dynFlags :: DynFlags
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-dynFlags = defaultDynFlags fakeSettings 
+dynFlags = defaultDynFlags fakeSettings
 #else
 dynFlags = defaultDynFlags fakeSettings fakeLlvmConfig
 #endif

--- a/src/HIndent/Pretty/Combinators/Outputable.hs
+++ b/src/HIndent/Pretty/Combinators/Outputable.hs
@@ -35,7 +35,7 @@ showOutputable = showPpr dynFlags
 
 -- | 'DynFlags' for calling 'showPpr'
 dynFlags :: DynFlags
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 dynFlags = defaultDynFlags fakeSettings
 #else
 dynFlags = defaultDynFlags fakeSettings fakeLlvmConfig

--- a/src/HIndent/Pretty/Combinators/String.hs
+++ b/src/HIndent/Pretty/Combinators/String.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Printer combinators related to print strings.
 module HIndent.Pretty.Combinators.String
   ( string
@@ -13,6 +14,9 @@ import qualified Data.ByteString.Builder as S
 import GHC.Stack
 import HIndent.Config
 import HIndent.Printer
+#if MIN_VERSION_GLASGOW_HASKELL(9,6,0,0)
+import Control.Monad
+#endif
 
 -- | This function prints the given string.
 --

--- a/src/HIndent/Pretty/Combinators/String.hs
+++ b/src/HIndent/Pretty/Combinators/String.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Printer combinators related to print strings.
 module HIndent.Pretty.Combinators.String
   ( string
@@ -17,7 +18,6 @@ import HIndent.Printer
 #if MIN_VERSION_GLASGOW_HASKELL(9,6,0,0)
 import Control.Monad
 #endif
-
 -- | This function prints the given string.
 --
 -- The string must not include '\n's. Use 'newline' to print them.

--- a/src/HIndent/Pretty/Combinators/Switch.hs
+++ b/src/HIndent/Pretty/Combinators/Switch.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase,CPP #-}
+{-# LANGUAGE LambdaCase, CPP #-}
 
 -- | Printer combinators for switching printers depending on situations.
 module HIndent.Pretty.Combinators.Switch
@@ -11,7 +11,6 @@ import HIndent.Printer
 #if MIN_VERSION_GLASGOW_HASKELL(9,6,0,0)
 import Control.Monad
 #endif
-
 -- | This function runs the first printer if the result of running it fits
 -- in a single line. Otherwise, it runs the second printer.
 (<-|>) :: Printer a -> Printer a -> Printer a

--- a/src/HIndent/Pretty/Combinators/Switch.hs
+++ b/src/HIndent/Pretty/Combinators/Switch.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase,CPP #-}
 
 -- | Printer combinators for switching printers depending on situations.
 module HIndent.Pretty.Combinators.Switch
@@ -8,6 +8,9 @@ module HIndent.Pretty.Combinators.Switch
 import Control.Applicative
 import Control.Monad.State
 import HIndent.Printer
+#if MIN_VERSION_GLASGOW_HASKELL(9,6,0,0)
+import Control.Monad
+#endif
 
 -- | This function runs the first printer if the result of running it fits
 -- in a single line. Otherwise, it runs the second printer.

--- a/src/HIndent/Pretty/Import.hs
+++ b/src/HIndent/Pretty/Import.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Helper functions for dealing with import declarations.
 module HIndent.Pretty.Import
   ( importsExist
@@ -11,17 +12,29 @@ import GHC.Types.SrcLoc
 import HIndent.Pretty.Import.Sort
 
 -- | Returns if the module has import declarations.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+importsExist :: (HsModule GhcPs) -> Bool
+#else
 importsExist :: HsModule -> Bool
+#endif
 importsExist = not . null . hsmodImports
 
 -- | Extracts import declarations from the given module. Adjacent import
 -- declarations are grouped as a single list.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+extractImports :: (HsModule GhcPs) -> [[LImportDecl GhcPs]]
+#else
 extractImports :: HsModule -> [[LImportDecl GhcPs]]
+#endif
 extractImports = groupImports . sortImportsByLocation . hsmodImports
 
 -- | Extracts import declarations from the given module and sorts them by
 -- their names. Adjacent import declarations are grouped as a single list.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+extractImportsSorted :: (HsModule GhcPs) -> [[LImportDecl GhcPs]]
+#else
 extractImportsSorted :: HsModule -> [[LImportDecl GhcPs]]
+#endif
 extractImportsSorted = fmap sortImportsByName . extractImports
 
 -- | Combines adjacent import declarations into a single list.

--- a/src/HIndent/Pretty/Import.hs
+++ b/src/HIndent/Pretty/Import.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Helper functions for dealing with import declarations.
 module HIndent.Pretty.Import
   ( importsExist
@@ -10,7 +11,6 @@ module HIndent.Pretty.Import
 import GHC.Hs
 import GHC.Types.SrcLoc
 import HIndent.Pretty.Import.Sort
-
 -- | Returns if the module has import declarations.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 importsExist :: (HsModule GhcPs) -> Bool
@@ -18,7 +18,6 @@ importsExist :: (HsModule GhcPs) -> Bool
 importsExist :: HsModule -> Bool
 #endif
 importsExist = not . null . hsmodImports
-
 -- | Extracts import declarations from the given module. Adjacent import
 -- declarations are grouped as a single list.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -27,7 +26,6 @@ extractImports :: (HsModule GhcPs) -> [[LImportDecl GhcPs]]
 extractImports :: HsModule -> [[LImportDecl GhcPs]]
 #endif
 extractImports = groupImports . sortImportsByLocation . hsmodImports
-
 -- | Extracts import declarations from the given module and sorts them by
 -- their names. Adjacent import declarations are grouped as a single list.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)

--- a/src/HIndent/Pretty/Import.hs
+++ b/src/HIndent/Pretty/Import.hs
@@ -12,7 +12,7 @@ import GHC.Hs
 import GHC.Types.SrcLoc
 import HIndent.Pretty.Import.Sort
 -- | Returns if the module has import declarations.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 importsExist :: (HsModule GhcPs) -> Bool
 #else
 importsExist :: HsModule -> Bool
@@ -20,7 +20,7 @@ importsExist :: HsModule -> Bool
 importsExist = not . null . hsmodImports
 -- | Extracts import declarations from the given module. Adjacent import
 -- declarations are grouped as a single list.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 extractImports :: (HsModule GhcPs) -> [[LImportDecl GhcPs]]
 #else
 extractImports :: HsModule -> [[LImportDecl GhcPs]]
@@ -28,7 +28,7 @@ extractImports :: HsModule -> [[LImportDecl GhcPs]]
 extractImports = groupImports . sortImportsByLocation . hsmodImports
 -- | Extracts import declarations from the given module and sorts them by
 -- their names. Adjacent import declarations are grouped as a single list.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 extractImportsSorted :: (HsModule GhcPs) -> [[LImportDecl GhcPs]]
 #else
 extractImportsSorted :: HsModule -> [[LImportDecl GhcPs]]

--- a/src/HIndent/Pretty/Import.hs
+++ b/src/HIndent/Pretty/Import.hs
@@ -12,7 +12,7 @@ import GHC.Hs
 import GHC.Types.SrcLoc
 import HIndent.Pretty.Import.Sort
 -- | Returns if the module has import declarations.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 importsExist :: (HsModule GhcPs) -> Bool
 #else
 importsExist :: HsModule -> Bool
@@ -20,7 +20,7 @@ importsExist :: HsModule -> Bool
 importsExist = not . null . hsmodImports
 -- | Extracts import declarations from the given module. Adjacent import
 -- declarations are grouped as a single list.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 extractImports :: (HsModule GhcPs) -> [[LImportDecl GhcPs]]
 #else
 extractImports :: HsModule -> [[LImportDecl GhcPs]]
@@ -28,7 +28,7 @@ extractImports :: HsModule -> [[LImportDecl GhcPs]]
 extractImports = groupImports . sortImportsByLocation . hsmodImports
 -- | Extracts import declarations from the given module and sorts them by
 -- their names. Adjacent import declarations are grouped as a single list.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 extractImportsSorted :: (HsModule GhcPs) -> [[LImportDecl GhcPs]]
 #else
 extractImportsSorted :: HsModule -> [[LImportDecl GhcPs]]

--- a/src/HIndent/Pretty/Import/Sort.hs
+++ b/src/HIndent/Pretty/Import/Sort.hs
@@ -44,7 +44,7 @@ sortByModuleName = sortBy (compare `on` unLoc . ideclName . unLoc)
 -- | This function sorts explicit imports in the given import declaration
 -- by their names.
 sortExplicitImportsInDecl :: LImportDecl GhcPs -> LImportDecl GhcPs
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 sortExplicitImportsInDecl (L l d@ImportDecl {ideclImportList = Just (x, imports)}) =
   L l d {ideclImportList = Just (x, sorted)}
   where

--- a/src/HIndent/Pretty/Import/Sort.hs
+++ b/src/HIndent/Pretty/Import/Sort.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Import declaration sorting for pretty-printing.
 module HIndent.Pretty.Import.Sort
   ( sortImportsByName
@@ -42,10 +43,17 @@ sortByModuleName = sortBy (compare `on` unLoc . ideclName . unLoc)
 -- | This function sorts explicit imports in the given import declaration
 -- by their names.
 sortExplicitImportsInDecl :: LImportDecl GhcPs -> LImportDecl GhcPs
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+sortExplicitImportsInDecl (L l d@ImportDecl {ideclImportList = Just (x, imports)}) =
+  L l d {ideclImportList = Just (x, sorted)}
+  where
+    sorted = fmap (fmap sortVariants . sortExplicitImports) imports
+#else
 sortExplicitImportsInDecl (L l d@ImportDecl {ideclHiding = Just (x, imports)}) =
   L l d {ideclHiding = Just (x, sorted)}
   where
     sorted = fmap (fmap sortVariants . sortExplicitImports) imports
+#endif
 sortExplicitImportsInDecl x = x
 
 -- | This function sorts the given explicit imports by their names.

--- a/src/HIndent/Pretty/Import/Sort.hs
+++ b/src/HIndent/Pretty/Import/Sort.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Import declaration sorting for pretty-printing.
 module HIndent.Pretty.Import.Sort
   ( sortImportsByName

--- a/src/HIndent/Pretty/Import/Sort.hs
+++ b/src/HIndent/Pretty/Import/Sort.hs
@@ -44,7 +44,7 @@ sortByModuleName = sortBy (compare `on` unLoc . ideclName . unLoc)
 -- | This function sorts explicit imports in the given import declaration
 -- by their names.
 sortExplicitImportsInDecl :: LImportDecl GhcPs -> LImportDecl GhcPs
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 sortExplicitImportsInDecl (L l d@ImportDecl {ideclImportList = Just (x, imports)}) =
   L l d {ideclImportList = Just (x, sorted)}
   where

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -24,6 +24,7 @@ import GHC.Unit
 import HIndent.Pretty.Pragma
 import HIndent.Pretty.SigBindFamily
 import HIndent.Pretty.Types
+import Data.Map.Internal.Debug (node)
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 import GHC.Core.DataCon
 #endif
@@ -245,6 +246,11 @@ nodeCommentsHsExpr HsRecSel {} = emptyNodeComments
 nodeCommentsHsExpr (HsTypedBracket x _) = nodeComments x
 nodeCommentsHsExpr (HsUntypedBracket x _) = nodeComments x
 #endif
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+nodeCommentsHsExpr (HsTypedSplice (x,y) _)=nodeComments x<>nodeComments y
+nodeCommentsHsExpr (HsUntypedSplice x _) =nodeComments x
+#endif
+
 instance CommentExtraction (HsSigType GhcPs) where
   nodeComments HsSig {} = emptyNodeComments
 

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -682,11 +682,18 @@ instance CommentExtraction (WarnDecl GhcPs) where
 instance CommentExtraction (WithHsDocIdentifiers StringLiteral GhcPs) where
   nodeComments WithHsDocIdentifiers {} = emptyNodeComments
 #endif
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance CommentExtraction (IEWrappedName GhcPs) where
+  nodeComments IEName {} = emptyNodeComments
+  nodeComments IEPattern {} = emptyNodeComments
+  nodeComments IEType {} = emptyNodeComments
+#else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance CommentExtraction (IEWrappedName RdrName) where
   nodeComments IEName {} = emptyNodeComments
   nodeComments IEPattern {} = emptyNodeComments
   nodeComments IEType {} = emptyNodeComments
+#endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (DotFieldOcc GhcPs) where
   nodeComments DotFieldOcc {..} = nodeComments dfoExt
@@ -976,7 +983,9 @@ instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction FieldLabelString where
-  nodeComments=const emptyNodeComments
+  nodeComments=undefined
+instance CommentExtraction(HsUntypedSplice GhcPs) where
+  nodeComments=undefined
 #endif
 
 -- | Marks an AST node as never appearing in the AST.

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -25,13 +25,13 @@ import GHC.Unit
 import HIndent.Pretty.Pragma
 import HIndent.Pretty.SigBindFamily
 import HIndent.Pretty.Types
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 import GHC.Core.DataCon
 #endif
 -- | An interface to extract comments from an AST node.
 class CommentExtraction a where
   nodeComments :: a -> NodeComments
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsModule GhcPs) where
   nodeComments =
     nodeComments . filterOutEofAndPragmasFromAnn . hsmodAnn . hsmodExt
@@ -84,7 +84,7 @@ instance CommentExtraction (HsDecl GhcPs) where
   nodeComments DocD {} =
     error "Document comments should be treated as normal ones."
   nodeComments RoleAnnotD {} = emptyNodeComments
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (TyClDecl GhcPs) where
   nodeComments FamDecl {} = emptyNodeComments
   nodeComments SynDecl {..} = nodeComments tcdSExt
@@ -102,7 +102,7 @@ instance CommentExtraction (InstDecl GhcPs) where
 
 nodeCommentsInstDecl :: InstDecl GhcPs -> NodeComments
 nodeCommentsInstDecl ClsInstD {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsInstDecl DataFamInstD {} = emptyNodeComments
 #else
 nodeCommentsInstDecl DataFamInstD {..} = nodeComments dfid_ext
@@ -120,7 +120,7 @@ nodeCommentsHsBind VarBind {} = emptyNodeComments
 nodeCommentsHsBind AbsBinds {} = emptyNodeComments
 #endif
 nodeCommentsHsBind PatSynBind {} = emptyNodeComments
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (Sig GhcPs) where
   nodeComments (TypeSig x _ _) = nodeComments x
   nodeComments (PatSynSig x _ _) = nodeComments x
@@ -177,7 +177,7 @@ nodeCommentsHsExpr (HsUnboundVar x _) = nodeComments x
 nodeCommentsHsExpr HsConLikeOut {} = emptyNodeComments
 nodeCommentsHsExpr HsRecFld {} = emptyNodeComments
 #endif
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 nodeCommentsHsExpr (HsOverLabel x _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsOverLabel x _) = nodeComments x
@@ -186,7 +186,7 @@ nodeCommentsHsExpr (HsIPVar x _) = nodeComments x
 nodeCommentsHsExpr (HsOverLit x _) = nodeComments x
 nodeCommentsHsExpr (HsLit x _) = nodeComments x
 nodeCommentsHsExpr HsLam {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsHsExpr (HsLamCase x _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsLamCase x _) = nodeComments x
@@ -195,7 +195,7 @@ nodeCommentsHsExpr (HsApp x _ _) = nodeComments x
 nodeCommentsHsExpr HsAppType {} = emptyNodeComments
 nodeCommentsHsExpr (OpApp x _ _ _) = nodeComments x
 nodeCommentsHsExpr (NegApp x _ _) = nodeComments x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsHsExpr (HsPar x _ _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsPar x _) = nodeComments x
@@ -207,7 +207,7 @@ nodeCommentsHsExpr (ExplicitSum x _ _ _) = nodeComments x
 nodeCommentsHsExpr (HsCase x _ _) = nodeComments x
 nodeCommentsHsExpr (HsIf x _ _ _) = nodeComments x
 nodeCommentsHsExpr (HsMultiIf x _) = nodeComments x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsHsExpr (HsLet x _ _ _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsLet x _ _) = nodeComments x
@@ -235,12 +235,12 @@ nodeCommentsHsExpr HsTick {} = emptyNodeComments
 nodeCommentsHsExpr HsBinTick {} = emptyNodeComments
 #endif
 nodeCommentsHsExpr HsPragE {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsHsExpr HsRecSel {} = emptyNodeComments
 nodeCommentsHsExpr (HsTypedBracket x _) = nodeComments x
 nodeCommentsHsExpr (HsUntypedBracket x _) = nodeComments x
 #endif
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 nodeCommentsHsExpr (HsTypedSplice (x, y) _) = nodeComments x <> nodeComments y
 nodeCommentsHsExpr (HsUntypedSplice x _) = nodeComments x
 #endif
@@ -346,7 +346,7 @@ nodeCommentsMatchContext StmtCtxt {} = emptyNodeComments
 nodeCommentsMatchContext ThPatSplice {} = emptyNodeComments
 nodeCommentsMatchContext ThPatQuote {} = emptyNodeComments
 nodeCommentsMatchContext PatSyn {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsMatchContext LamCaseAlt {} = emptyNodeComments
 #endif
 instance CommentExtraction (ParStmtBlock GhcPs GhcPs) where
@@ -392,12 +392,12 @@ nodeCommentsPat :: Pat GhcPs -> NodeComments
 nodeCommentsPat WildPat {} = emptyNodeComments
 nodeCommentsPat VarPat {} = emptyNodeComments
 nodeCommentsPat (LazyPat x _) = nodeComments x
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 nodeCommentsPat (AsPat x _ _ _) = nodeComments x
 #else
 nodeCommentsPat (AsPat x _ _) = nodeComments x
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsPat (ParPat x _ _ _) = nodeComments x
 #else
 nodeCommentsPat (ParPat x _) = nodeComments x
@@ -469,7 +469,7 @@ instance CommentExtraction (HsValBindsLR GhcPs GhcPs) where
 instance CommentExtraction (HsTupArg GhcPs) where
   nodeComments (Present x _) = nodeComments x
   nodeComments (Missing x) = nodeComments x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction RecConField where
   nodeComments (RecConField x) = nodeComments x
 #else
@@ -483,7 +483,7 @@ instance CommentExtraction
            (HsRecField' (FieldOcc GhcPs) (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
   nodeComments HsRecField {..} = nodeComments hsRecFieldAnn
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 -- | For pattern matchings against records.
 instance CommentExtraction
            (HsFieldBind
@@ -501,7 +501,7 @@ instance CommentExtraction
 instance CommentExtraction RecConField where
   nodeComments (RecConField x) = nodeComments x
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (FieldOcc GhcPs) where
   nodeComments FieldOcc {} = emptyNodeComments
 #else
@@ -547,7 +547,7 @@ instance CommentExtraction (AmbiguousFieldOcc GhcPs) where
 
 instance CommentExtraction (ImportDecl GhcPs) where
   nodeComments ImportDecl {..} = nodeComments ideclExt
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction XImportDeclPass where
   nodeComments XImportDeclPass {..} = nodeComments ideclAnn
 #endif
@@ -602,7 +602,7 @@ instance CommentExtraction PrefixOp where
 
 instance CommentExtraction Context where
   nodeComments Context {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction HorizontalContext where
   nodeComments HorizontalContext {} = emptyNodeComments
 
@@ -652,7 +652,7 @@ instance CommentExtraction
   nodeComments HsValArg {} = emptyNodeComments
   nodeComments HsTypeArg {} = emptyNodeComments
   nodeComments HsArgPar {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (HsQuote GhcPs) where
   nodeComments ExpBr {} = emptyNodeComments
   nodeComments PatBr {} = emptyNodeComments
@@ -662,7 +662,7 @@ instance CommentExtraction (HsQuote GhcPs) where
   nodeComments VarBr {} = emptyNodeComments
 #endif
 
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (WarnDecls GhcPs) where
   nodeComments Warnings {..} = nodeComments $ fst wd_ext
 #else
@@ -671,11 +671,11 @@ instance CommentExtraction (WarnDecls GhcPs) where
 #endif
 instance CommentExtraction (WarnDecl GhcPs) where
   nodeComments (Warning x _ _) = nodeComments x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (WithHsDocIdentifiers StringLiteral GhcPs) where
   nodeComments WithHsDocIdentifiers {} = emptyNodeComments
 #endif
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (IEWrappedName GhcPs) where
   nodeComments IEName {} = emptyNodeComments
   nodeComments IEPattern {} = emptyNodeComments
@@ -687,7 +687,7 @@ instance CommentExtraction (IEWrappedName RdrName) where
   nodeComments IEPattern {} = emptyNodeComments
   nodeComments IEType {} = emptyNodeComments
 #endif
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance CommentExtraction (DotFieldOcc GhcPs) where
   nodeComments DotFieldOcc {..} = nodeComments dfoExt
 #else
@@ -695,7 +695,7 @@ instance CommentExtraction (HsFieldLabel GhcPs) where
   nodeComments HsFieldLabel {..} = nodeComments hflExt
 #endif
 
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (RuleDecls GhcPs) where
   nodeComments HsRules {..} = nodeComments $ fst rds_ext
 #else
@@ -703,7 +703,7 @@ instance CommentExtraction (RuleDecls GhcPs) where
   nodeComments HsRules {..} = nodeComments rds_ext
 #endif
 
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (RuleDecl GhcPs) where
   nodeComments HsRule {..} = nodeComments $ fst rd_ext
 #else
@@ -735,7 +735,7 @@ instance CommentExtraction (DefaultDecl GhcPs) where
 instance CommentExtraction (ForeignDecl GhcPs) where
   nodeComments ForeignImport {..} = nodeComments fd_i_ext
   nodeComments ForeignExport {..} = nodeComments fd_e_ext
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (ForeignImport GhcPs) where
   nodeComments CImport {} = emptyNodeComments
 #else
@@ -743,7 +743,7 @@ instance CommentExtraction ForeignImport where
   nodeComments CImport {} = emptyNodeComments
 #endif
 
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (ForeignExport GhcPs) where
   nodeComments CExport {} = emptyNodeComments
 #else
@@ -757,7 +757,7 @@ instance CommentExtraction Safety where
   nodeComments PlaySafe = emptyNodeComments
   nodeComments PlayInterruptible = emptyNodeComments
   nodeComments PlayRisky = emptyNodeComments
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (AnnDecl GhcPs) where
   nodeComments (HsAnnotation (x, _) _ _) = nodeComments x
 #else
@@ -819,7 +819,7 @@ nodeCommentsInlineSpec Inline {} = emptyNodeComments
 nodeCommentsInlineSpec Inlinable {} = emptyNodeComments
 nodeCommentsInlineSpec NoInline {} = emptyNodeComments
 nodeCommentsInlineSpec NoUserInlinePrag {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsInlineSpec Opaque {} = emptyNodeComments
 #endif
 instance CommentExtraction (HsPatSynDir GhcPs) where
@@ -855,7 +855,7 @@ instance CommentExtraction (HsLit GhcPs) where
   nodeComments HsRat {} = emptyNodeComments
   nodeComments HsFloatPrim {} = emptyNodeComments
   nodeComments HsDoublePrim {} = emptyNodeComments
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsPragE GhcPs) where
   nodeComments (HsPragSCC (x, _) _) = nodeComments x
 #else
@@ -864,7 +864,7 @@ instance CommentExtraction (HsPragE GhcPs) where
 #endif
 instance CommentExtraction HsIPName where
   nodeComments HsIPName {} = emptyNodeComments
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsTyLit GhcPs) where
   nodeComments HsNumTy {} = emptyNodeComments
   nodeComments HsStrTy {} = emptyNodeComments
@@ -907,19 +907,19 @@ nodeCommentsHsCmd (HsCmdArrApp x _ _ _ _) = nodeComments x
 nodeCommentsHsCmd (HsCmdArrForm x _ _ _ _) = nodeComments x
 nodeCommentsHsCmd (HsCmdApp x _ _) = nodeComments x
 nodeCommentsHsCmd HsCmdLam {} = emptyNodeComments
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsHsCmd (HsCmdPar x _ _ _) = nodeComments x
 #else
 nodeCommentsHsCmd (HsCmdPar x _) = nodeComments x
 #endif
 nodeCommentsHsCmd (HsCmdCase x _ _) = nodeComments x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsHsCmd (HsCmdLamCase x _ _) = nodeComments x
 #else
 nodeCommentsHsCmd (HsCmdLamCase x _) = nodeComments x
 #endif
 nodeCommentsHsCmd (HsCmdIf x _ _ _ _) = nodeComments x
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 nodeCommentsHsCmd (HsCmdLet x _ _ _ _) = nodeComments x
 #else
 nodeCommentsHsCmd (HsCmdLet x _ _) = nodeComments x
@@ -961,7 +961,7 @@ instance CommentExtraction SrcStrictness where
 instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
   nodeComments HsOuterImplicit {} = emptyNodeComments
   nodeComments HsOuterExplicit {..} = nodeComments hso_xexplicit
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction FieldLabelString where
   nodeComments = const emptyNodeComments
 

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -8,6 +8,7 @@ module HIndent.Pretty.NodeComments
   , emptyNodeComments
   ) where
 
+import Data.Map.Internal.Debug (node)
 import Data.Void
 import GHC.Core.Coercion
 import GHC.Data.BooleanFormula
@@ -24,18 +25,16 @@ import GHC.Unit
 import HIndent.Pretty.Pragma
 import HIndent.Pretty.SigBindFamily
 import HIndent.Pretty.Types
-import Data.Map.Internal.Debug (node)
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 import GHC.Core.DataCon
 #endif
-
 -- | An interface to extract comments from an AST node.
 class CommentExtraction a where
   nodeComments :: a -> NodeComments
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsModule GhcPs) where
-  nodeComments = nodeComments . filterOutEofAndPragmasFromAnn . hsmodAnn . hsmodExt
+  nodeComments =
+    nodeComments . filterOutEofAndPragmasFromAnn . hsmodAnn . hsmodExt
     where
       filterOutEofAndPragmasFromAnn EpAnn {..} =
         EpAnn {comments = filterOutEofAndPragmasFromComments comments, ..}
@@ -66,7 +65,6 @@ instance CommentExtraction HsModule where
       isNeitherEofNorPragmaComment (L _ (EpaComment EpaEofComment _)) = False
       isNeitherEofNorPragmaComment (L _ (EpaComment tok _)) = not $ isPragma tok
 #endif
-
 instance CommentExtraction l => CommentExtraction (GenLocated l e) where
   nodeComments (L l _) = nodeComments l
 
@@ -86,7 +84,6 @@ instance CommentExtraction (HsDecl GhcPs) where
   nodeComments DocD {} =
     error "Document comments should be treated as normal ones."
   nodeComments RoleAnnotD {} = emptyNodeComments
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (TyClDecl GhcPs) where
   nodeComments FamDecl {} = emptyNodeComments
@@ -100,7 +97,6 @@ instance CommentExtraction (TyClDecl GhcPs) where
   nodeComments DataDecl {..} = nodeComments tcdDExt
   nodeComments ClassDecl {tcdCExt = (x, _, _)} = nodeComments x
 #endif
-
 instance CommentExtraction (InstDecl GhcPs) where
   nodeComments = nodeCommentsInstDecl
 
@@ -124,7 +120,6 @@ nodeCommentsHsBind VarBind {} = emptyNodeComments
 nodeCommentsHsBind AbsBinds {} = emptyNodeComments
 #endif
 nodeCommentsHsBind PatSynBind {} = emptyNodeComments
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (Sig GhcPs) where
   nodeComments (TypeSig x _ _) = nodeComments x
@@ -133,10 +128,10 @@ instance CommentExtraction (Sig GhcPs) where
   nodeComments (FixSig x _) = nodeComments x
   nodeComments (InlineSig x _ _) = nodeComments x
   nodeComments (SpecSig x _ _ _) = nodeComments x
-  nodeComments (SpecInstSig x  _) = nodeComments $ fst x
-  nodeComments (MinimalSig x  _) = nodeComments $ fst x
-  nodeComments (SCCFunSig x _  _) = nodeComments $ fst x
-  nodeComments (CompleteMatchSig x _ _ ) = nodeComments $ fst x
+  nodeComments (SpecInstSig x _) = nodeComments $ fst x
+  nodeComments (MinimalSig x _) = nodeComments $ fst x
+  nodeComments (SCCFunSig x _ _) = nodeComments $ fst x
+  nodeComments (CompleteMatchSig x _ _) = nodeComments $ fst x
 #else
 instance CommentExtraction (Sig GhcPs) where
   nodeComments (TypeSig x _ _) = nodeComments x
@@ -151,7 +146,6 @@ instance CommentExtraction (Sig GhcPs) where
   nodeComments (SCCFunSig x _ _ _) = nodeComments x
   nodeComments (CompleteMatchSig x _ _ _) = nodeComments x
 #endif
-
 instance CommentExtraction DeclSig where
   nodeComments (DeclSig x) = nodeComments x
 
@@ -247,10 +241,9 @@ nodeCommentsHsExpr (HsTypedBracket x _) = nodeComments x
 nodeCommentsHsExpr (HsUntypedBracket x _) = nodeComments x
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-nodeCommentsHsExpr (HsTypedSplice (x,y) _)=nodeComments x<>nodeComments y
-nodeCommentsHsExpr (HsUntypedSplice x _) =nodeComments x
+nodeCommentsHsExpr (HsTypedSplice (x, y) _) = nodeComments x <> nodeComments y
+nodeCommentsHsExpr (HsUntypedSplice x _) = nodeComments x
 #endif
-
 instance CommentExtraction (HsSigType GhcPs) where
   nodeComments HsSig {} = emptyNodeComments
 
@@ -382,7 +375,6 @@ instance CommentExtraction EpaCommentTok where
 
 instance CommentExtraction (SpliceDecl GhcPs) where
   nodeComments SpliceDecl {} = emptyNodeComments
-
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsSplice GhcPs) where
   nodeComments (HsTypedSplice x _ _ _) = nodeComments x
@@ -390,7 +382,6 @@ instance CommentExtraction (HsSplice GhcPs) where
   nodeComments HsQuasiQuote {} = emptyNodeComments
   nodeComments HsSpliced {} = emptyNodeComments
 #endif
-
 instance CommentExtraction (Pat GhcPs) where
   nodeComments = nodeCommentsPat
 
@@ -556,12 +547,10 @@ instance CommentExtraction (AmbiguousFieldOcc GhcPs) where
 
 instance CommentExtraction (ImportDecl GhcPs) where
   nodeComments ImportDecl {..} = nodeComments ideclExt
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction XImportDeclPass where
-  nodeComments XImportDeclPass{..}=nodeComments ideclAnn
+  nodeComments XImportDeclPass {..} = nodeComments ideclAnn
 #endif
-
 instance CommentExtraction (HsDerivingClause GhcPs) where
   nodeComments HsDerivingClause {..} = nodeComments deriv_clause_ext
 
@@ -680,8 +669,6 @@ instance CommentExtraction (WarnDecls GhcPs) where
 instance CommentExtraction (WarnDecls GhcPs) where
   nodeComments Warnings {..} = nodeComments wd_ext
 #endif
-
-
 instance CommentExtraction (WarnDecl GhcPs) where
   nodeComments (Warning x _ _) = nodeComments x
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -716,7 +703,6 @@ instance CommentExtraction (RuleDecls GhcPs) where
   nodeComments HsRules {..} = nodeComments rds_ext
 #endif
 
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (RuleDecl GhcPs) where
   nodeComments HsRule {..} = nodeComments $ fst rd_ext
@@ -724,8 +710,6 @@ instance CommentExtraction (RuleDecl GhcPs) where
 instance CommentExtraction (RuleDecl GhcPs) where
   nodeComments HsRule {..} = nodeComments rd_ext
 #endif
-
-
 instance CommentExtraction OccName where
   nodeComments = const emptyNodeComments
 
@@ -751,7 +735,6 @@ instance CommentExtraction (DefaultDecl GhcPs) where
 instance CommentExtraction (ForeignDecl GhcPs) where
   nodeComments ForeignImport {..} = nodeComments fd_i_ext
   nodeComments ForeignExport {..} = nodeComments fd_e_ext
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (ForeignImport GhcPs) where
   nodeComments CImport {} = emptyNodeComments
@@ -767,7 +750,6 @@ instance CommentExtraction (ForeignExport GhcPs) where
 instance CommentExtraction ForeignExport where
   nodeComments CExport {} = emptyNodeComments
 #endif
-
 instance CommentExtraction CExportSpec where
   nodeComments CExportStatic {} = emptyNodeComments
 
@@ -775,16 +757,13 @@ instance CommentExtraction Safety where
   nodeComments PlaySafe = emptyNodeComments
   nodeComments PlayInterruptible = emptyNodeComments
   nodeComments PlayRisky = emptyNodeComments
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (AnnDecl GhcPs) where
-  nodeComments (HsAnnotation (x,_) _ _ ) = nodeComments x
+  nodeComments (HsAnnotation (x, _) _ _) = nodeComments x
 #else
 instance CommentExtraction (AnnDecl GhcPs) where
   nodeComments (HsAnnotation x _ _ _) = nodeComments x
 #endif
-
-
 instance CommentExtraction (RoleAnnotDecl GhcPs) where
   nodeComments (RoleAnnotDecl x _ _) = nodeComments x
 
@@ -876,20 +855,17 @@ instance CommentExtraction (HsLit GhcPs) where
   nodeComments HsRat {} = emptyNodeComments
   nodeComments HsFloatPrim {} = emptyNodeComments
   nodeComments HsDoublePrim {} = emptyNodeComments
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction (HsPragE GhcPs) where
-  nodeComments (HsPragSCC (x ,_) _) = nodeComments x
+  nodeComments (HsPragSCC (x, _) _) = nodeComments x
 #else
 instance CommentExtraction (HsPragE GhcPs) where
   nodeComments (HsPragSCC x _ _) = nodeComments x
 #endif
-
 instance CommentExtraction HsIPName where
   nodeComments HsIPName {} = emptyNodeComments
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-instance CommentExtraction (HsTyLit GhcPs)where
+instance CommentExtraction (HsTyLit GhcPs) where
   nodeComments HsNumTy {} = emptyNodeComments
   nodeComments HsStrTy {} = emptyNodeComments
   nodeComments HsCharTy {} = emptyNodeComments
@@ -899,7 +875,6 @@ instance CommentExtraction HsTyLit where
   nodeComments HsStrTy {} = emptyNodeComments
   nodeComments HsCharTy {} = emptyNodeComments
 #endif
-
 instance CommentExtraction (HsPatSigType GhcPs) where
   nodeComments HsPS {..} = nodeComments hsps_ext
 
@@ -986,15 +961,14 @@ instance CommentExtraction SrcStrictness where
 instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
   nodeComments HsOuterImplicit {} = emptyNodeComments
   nodeComments HsOuterExplicit {..} = nodeComments hso_xexplicit
-
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction FieldLabelString where
-  nodeComments=const emptyNodeComments
-instance CommentExtraction(HsUntypedSplice GhcPs) where
-  nodeComments (HsUntypedSpliceExpr x _)=nodeComments x
-  nodeComments HsQuasiQuote{}=emptyNodeComments
-#endif
+  nodeComments = const emptyNodeComments
 
+instance CommentExtraction (HsUntypedSplice GhcPs) where
+  nodeComments (HsUntypedSpliceExpr x _) = nodeComments x
+  nodeComments HsQuasiQuote {} = emptyNodeComments
+#endif
 -- | Marks an AST node as never appearing in the AST.
 --
 -- Some AST node types are only used in the renaming or type-checking phase.

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -991,7 +991,8 @@ instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
 instance CommentExtraction FieldLabelString where
   nodeComments=undefined
 instance CommentExtraction(HsUntypedSplice GhcPs) where
-  nodeComments=undefined
+  nodeComments (HsUntypedSpliceExpr x _)=nodeComments x
+  nodeComments HsQuasiQuote{}=emptyNodeComments
 #endif
 
 -- | Marks an AST node as never appearing in the AST.

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -25,13 +25,13 @@ import GHC.Unit
 import HIndent.Pretty.Pragma
 import HIndent.Pretty.SigBindFamily
 import HIndent.Pretty.Types
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 import GHC.Core.DataCon
 #endif
 -- | An interface to extract comments from an AST node.
 class CommentExtraction a where
   nodeComments :: a -> NodeComments
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (HsModule GhcPs) where
   nodeComments =
     nodeComments . filterOutEofAndPragmasFromAnn . hsmodAnn . hsmodExt
@@ -84,7 +84,7 @@ instance CommentExtraction (HsDecl GhcPs) where
   nodeComments DocD {} =
     error "Document comments should be treated as normal ones."
   nodeComments RoleAnnotD {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (TyClDecl GhcPs) where
   nodeComments FamDecl {} = emptyNodeComments
   nodeComments SynDecl {..} = nodeComments tcdSExt
@@ -102,7 +102,7 @@ instance CommentExtraction (InstDecl GhcPs) where
 
 nodeCommentsInstDecl :: InstDecl GhcPs -> NodeComments
 nodeCommentsInstDecl ClsInstD {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsInstDecl DataFamInstD {} = emptyNodeComments
 #else
 nodeCommentsInstDecl DataFamInstD {..} = nodeComments dfid_ext
@@ -120,7 +120,7 @@ nodeCommentsHsBind VarBind {} = emptyNodeComments
 nodeCommentsHsBind AbsBinds {} = emptyNodeComments
 #endif
 nodeCommentsHsBind PatSynBind {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (Sig GhcPs) where
   nodeComments (TypeSig x _ _) = nodeComments x
   nodeComments (PatSynSig x _ _) = nodeComments x
@@ -177,7 +177,7 @@ nodeCommentsHsExpr (HsUnboundVar x _) = nodeComments x
 nodeCommentsHsExpr HsConLikeOut {} = emptyNodeComments
 nodeCommentsHsExpr HsRecFld {} = emptyNodeComments
 #endif
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 nodeCommentsHsExpr (HsOverLabel x _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsOverLabel x _) = nodeComments x
@@ -186,7 +186,7 @@ nodeCommentsHsExpr (HsIPVar x _) = nodeComments x
 nodeCommentsHsExpr (HsOverLit x _) = nodeComments x
 nodeCommentsHsExpr (HsLit x _) = nodeComments x
 nodeCommentsHsExpr HsLam {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsHsExpr (HsLamCase x _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsLamCase x _) = nodeComments x
@@ -195,7 +195,7 @@ nodeCommentsHsExpr (HsApp x _ _) = nodeComments x
 nodeCommentsHsExpr HsAppType {} = emptyNodeComments
 nodeCommentsHsExpr (OpApp x _ _ _) = nodeComments x
 nodeCommentsHsExpr (NegApp x _ _) = nodeComments x
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsHsExpr (HsPar x _ _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsPar x _) = nodeComments x
@@ -207,7 +207,7 @@ nodeCommentsHsExpr (ExplicitSum x _ _ _) = nodeComments x
 nodeCommentsHsExpr (HsCase x _ _) = nodeComments x
 nodeCommentsHsExpr (HsIf x _ _ _) = nodeComments x
 nodeCommentsHsExpr (HsMultiIf x _) = nodeComments x
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsHsExpr (HsLet x _ _ _ _) = nodeComments x
 #else
 nodeCommentsHsExpr (HsLet x _ _) = nodeComments x
@@ -235,12 +235,12 @@ nodeCommentsHsExpr HsTick {} = emptyNodeComments
 nodeCommentsHsExpr HsBinTick {} = emptyNodeComments
 #endif
 nodeCommentsHsExpr HsPragE {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsHsExpr HsRecSel {} = emptyNodeComments
 nodeCommentsHsExpr (HsTypedBracket x _) = nodeComments x
 nodeCommentsHsExpr (HsUntypedBracket x _) = nodeComments x
 #endif
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 nodeCommentsHsExpr (HsTypedSplice (x, y) _) = nodeComments x <> nodeComments y
 nodeCommentsHsExpr (HsUntypedSplice x _) = nodeComments x
 #endif
@@ -346,7 +346,7 @@ nodeCommentsMatchContext StmtCtxt {} = emptyNodeComments
 nodeCommentsMatchContext ThPatSplice {} = emptyNodeComments
 nodeCommentsMatchContext ThPatQuote {} = emptyNodeComments
 nodeCommentsMatchContext PatSyn {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsMatchContext LamCaseAlt {} = emptyNodeComments
 #endif
 instance CommentExtraction (ParStmtBlock GhcPs GhcPs) where
@@ -392,12 +392,12 @@ nodeCommentsPat :: Pat GhcPs -> NodeComments
 nodeCommentsPat WildPat {} = emptyNodeComments
 nodeCommentsPat VarPat {} = emptyNodeComments
 nodeCommentsPat (LazyPat x _) = nodeComments x
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 nodeCommentsPat (AsPat x _ _ _) = nodeComments x
 #else
 nodeCommentsPat (AsPat x _ _) = nodeComments x
 #endif
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsPat (ParPat x _ _ _) = nodeComments x
 #else
 nodeCommentsPat (ParPat x _) = nodeComments x
@@ -469,7 +469,7 @@ instance CommentExtraction (HsValBindsLR GhcPs GhcPs) where
 instance CommentExtraction (HsTupArg GhcPs) where
   nodeComments (Present x _) = nodeComments x
   nodeComments (Missing x) = nodeComments x
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 instance CommentExtraction RecConField where
   nodeComments (RecConField x) = nodeComments x
 #else
@@ -483,7 +483,7 @@ instance CommentExtraction
            (HsRecField' (FieldOcc GhcPs) (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
   nodeComments HsRecField {..} = nodeComments hsRecFieldAnn
 #endif
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 -- | For pattern matchings against records.
 instance CommentExtraction
            (HsFieldBind
@@ -501,7 +501,7 @@ instance CommentExtraction
 instance CommentExtraction RecConField where
   nodeComments (RecConField x) = nodeComments x
 #endif
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 instance CommentExtraction (FieldOcc GhcPs) where
   nodeComments FieldOcc {} = emptyNodeComments
 #else
@@ -547,7 +547,7 @@ instance CommentExtraction (AmbiguousFieldOcc GhcPs) where
 
 instance CommentExtraction (ImportDecl GhcPs) where
   nodeComments ImportDecl {..} = nodeComments ideclExt
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction XImportDeclPass where
   nodeComments XImportDeclPass {..} = nodeComments ideclAnn
 #endif
@@ -602,7 +602,7 @@ instance CommentExtraction PrefixOp where
 
 instance CommentExtraction Context where
   nodeComments Context {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 instance CommentExtraction HorizontalContext where
   nodeComments HorizontalContext {} = emptyNodeComments
 
@@ -652,7 +652,7 @@ instance CommentExtraction
   nodeComments HsValArg {} = emptyNodeComments
   nodeComments HsTypeArg {} = emptyNodeComments
   nodeComments HsArgPar {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 instance CommentExtraction (HsQuote GhcPs) where
   nodeComments ExpBr {} = emptyNodeComments
   nodeComments PatBr {} = emptyNodeComments
@@ -662,7 +662,7 @@ instance CommentExtraction (HsQuote GhcPs) where
   nodeComments VarBr {} = emptyNodeComments
 #endif
 
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (WarnDecls GhcPs) where
   nodeComments Warnings {..} = nodeComments $ fst wd_ext
 #else
@@ -671,11 +671,11 @@ instance CommentExtraction (WarnDecls GhcPs) where
 #endif
 instance CommentExtraction (WarnDecl GhcPs) where
   nodeComments (Warning x _ _) = nodeComments x
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 instance CommentExtraction (WithHsDocIdentifiers StringLiteral GhcPs) where
   nodeComments WithHsDocIdentifiers {} = emptyNodeComments
 #endif
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (IEWrappedName GhcPs) where
   nodeComments IEName {} = emptyNodeComments
   nodeComments IEPattern {} = emptyNodeComments
@@ -687,7 +687,7 @@ instance CommentExtraction (IEWrappedName RdrName) where
   nodeComments IEPattern {} = emptyNodeComments
   nodeComments IEType {} = emptyNodeComments
 #endif
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 instance CommentExtraction (DotFieldOcc GhcPs) where
   nodeComments DotFieldOcc {..} = nodeComments dfoExt
 #else
@@ -695,7 +695,7 @@ instance CommentExtraction (HsFieldLabel GhcPs) where
   nodeComments HsFieldLabel {..} = nodeComments hflExt
 #endif
 
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (RuleDecls GhcPs) where
   nodeComments HsRules {..} = nodeComments $ fst rds_ext
 #else
@@ -703,7 +703,7 @@ instance CommentExtraction (RuleDecls GhcPs) where
   nodeComments HsRules {..} = nodeComments rds_ext
 #endif
 
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (RuleDecl GhcPs) where
   nodeComments HsRule {..} = nodeComments $ fst rd_ext
 #else
@@ -735,7 +735,7 @@ instance CommentExtraction (DefaultDecl GhcPs) where
 instance CommentExtraction (ForeignDecl GhcPs) where
   nodeComments ForeignImport {..} = nodeComments fd_i_ext
   nodeComments ForeignExport {..} = nodeComments fd_e_ext
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (ForeignImport GhcPs) where
   nodeComments CImport {} = emptyNodeComments
 #else
@@ -743,7 +743,7 @@ instance CommentExtraction ForeignImport where
   nodeComments CImport {} = emptyNodeComments
 #endif
 
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (ForeignExport GhcPs) where
   nodeComments CExport {} = emptyNodeComments
 #else
@@ -757,7 +757,7 @@ instance CommentExtraction Safety where
   nodeComments PlaySafe = emptyNodeComments
   nodeComments PlayInterruptible = emptyNodeComments
   nodeComments PlayRisky = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (AnnDecl GhcPs) where
   nodeComments (HsAnnotation (x, _) _ _) = nodeComments x
 #else
@@ -819,7 +819,7 @@ nodeCommentsInlineSpec Inline {} = emptyNodeComments
 nodeCommentsInlineSpec Inlinable {} = emptyNodeComments
 nodeCommentsInlineSpec NoInline {} = emptyNodeComments
 nodeCommentsInlineSpec NoUserInlinePrag {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsInlineSpec Opaque {} = emptyNodeComments
 #endif
 instance CommentExtraction (HsPatSynDir GhcPs) where
@@ -855,7 +855,7 @@ instance CommentExtraction (HsLit GhcPs) where
   nodeComments HsRat {} = emptyNodeComments
   nodeComments HsFloatPrim {} = emptyNodeComments
   nodeComments HsDoublePrim {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (HsPragE GhcPs) where
   nodeComments (HsPragSCC (x, _) _) = nodeComments x
 #else
@@ -864,7 +864,7 @@ instance CommentExtraction (HsPragE GhcPs) where
 #endif
 instance CommentExtraction HsIPName where
   nodeComments HsIPName {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction (HsTyLit GhcPs) where
   nodeComments HsNumTy {} = emptyNodeComments
   nodeComments HsStrTy {} = emptyNodeComments
@@ -907,19 +907,19 @@ nodeCommentsHsCmd (HsCmdArrApp x _ _ _ _) = nodeComments x
 nodeCommentsHsCmd (HsCmdArrForm x _ _ _ _) = nodeComments x
 nodeCommentsHsCmd (HsCmdApp x _ _) = nodeComments x
 nodeCommentsHsCmd HsCmdLam {} = emptyNodeComments
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsHsCmd (HsCmdPar x _ _ _) = nodeComments x
 #else
 nodeCommentsHsCmd (HsCmdPar x _) = nodeComments x
 #endif
 nodeCommentsHsCmd (HsCmdCase x _ _) = nodeComments x
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsHsCmd (HsCmdLamCase x _ _) = nodeComments x
 #else
 nodeCommentsHsCmd (HsCmdLamCase x _) = nodeComments x
 #endif
 nodeCommentsHsCmd (HsCmdIf x _ _ _ _) = nodeComments x
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 nodeCommentsHsCmd (HsCmdLet x _ _ _ _) = nodeComments x
 #else
 nodeCommentsHsCmd (HsCmdLet x _ _) = nodeComments x
@@ -961,7 +961,7 @@ instance CommentExtraction SrcStrictness where
 instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
   nodeComments HsOuterImplicit {} = emptyNodeComments
   nodeComments HsOuterExplicit {..} = nodeComments hso_xexplicit
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 instance CommentExtraction FieldLabelString where
   nodeComments = const emptyNodeComments
 

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -24,6 +24,9 @@ import GHC.Unit
 import HIndent.Pretty.Pragma
 import HIndent.Pretty.SigBindFamily
 import HIndent.Pretty.Types
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+import GHC.Core.DataCon
+#endif
 
 -- | An interface to extract comments from an AST node.
 class CommentExtraction a where
@@ -970,6 +973,11 @@ instance CommentExtraction SrcStrictness where
 instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
   nodeComments HsOuterImplicit {} = emptyNodeComments
   nodeComments HsOuterExplicit {..} = nodeComments hso_xexplicit
+
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+instance CommentExtraction FieldLabelString where
+  nodeComments=const emptyNodeComments
+#endif
 
 -- | Marks an AST node as never appearing in the AST.
 --

--- a/src/HIndent/Pretty/NodeComments.hs
+++ b/src/HIndent/Pretty/NodeComments.hs
@@ -989,7 +989,7 @@ instance CommentExtraction (HsOuterSigTyVarBndrs GhcPs) where
 
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance CommentExtraction FieldLabelString where
-  nodeComments=undefined
+  nodeComments=const emptyNodeComments
 instance CommentExtraction(HsUntypedSplice GhcPs) where
   nodeComments (HsUntypedSpliceExpr x _)=nodeComments x
   nodeComments HsQuasiQuote{}=emptyNodeComments

--- a/src/HIndent/Pretty/Pragma.hs
+++ b/src/HIndent/Pretty/Pragma.hs
@@ -20,7 +20,7 @@ import HIndent.Pretty.Combinators.String
 import HIndent.Printer
 import Text.Regex.TDFA
 -- | This function pretty-prints the module's pragmas
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyPragmas :: HsModule GhcPs -> Printer ()
 #else
 prettyPragmas :: HsModule -> Printer ()
@@ -28,7 +28,7 @@ prettyPragmas :: HsModule -> Printer ()
 prettyPragmas = lined . fmap string . collectPragmas
 -- | This function returns a 'True' if the module has pragmas.
 -- Otherwise, it returns a 'False'.
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 pragmaExists :: HsModule GhcPs -> Bool
 #else
 pragmaExists :: HsModule -> Bool
@@ -39,7 +39,7 @@ pragmaExists = not . null . collectPragmas
 --
 -- A pragma's name is converted to the @SHOUT_CASE@ (e.g., @lAnGuAgE@ ->
 -- @LANGUAGE@).
-#if GLP961
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
 collectPragmas :: HsModule GhcPs -> [String]
 collectPragmas =
   fmap (uncurry constructPragma) .

--- a/src/HIndent/Pretty/Pragma.hs
+++ b/src/HIndent/Pretty/Pragma.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Pretty-printing pragmas
 module HIndent.Pretty.Pragma
   ( prettyPragmas
@@ -19,12 +20,20 @@ import HIndent.Printer
 import Text.Regex.TDFA
 
 -- | This function pretty-prints the module's pragmas
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+prettyPragmas :: HsModule GhcPs -> Printer ()
+#else
 prettyPragmas :: HsModule -> Printer ()
+#endif
 prettyPragmas = lined . fmap string . collectPragmas
 
 -- | This function returns a 'True' if the module has pragmas.
 -- Otherwise, it returns a 'False'.
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+pragmaExists :: HsModule GhcPs -> Bool
+#else
 pragmaExists :: HsModule -> Bool
+#endif
 pragmaExists = not . null . collectPragmas
 
 -- | This function collects pragma comments from the
@@ -32,17 +41,17 @@ pragmaExists = not . null . collectPragmas
 --
 -- A pragma's name is converted to the @SHOUT_CASE@ (e.g., @lAnGuAgE@ ->
 -- @LANGUAGE@).
+#if MIN_VERSION_ghc_lib_parser(9,6,1)
+collectPragmas :: HsModule GhcPs -> [String]
+collectPragmas =
+  fmap (uncurry constructPragma) .
+  mapMaybe extractPragma . listify isBlockComment . hsmodAnn . hsmodExt
+#else
 collectPragmas :: HsModule -> [String]
 collectPragmas =
   fmap (uncurry constructPragma) .
-  mapMaybe extractPragma . listify matchToComment . hsmodAnn
-  where
-    matchToComment :: EpaCommentTok -> Bool
-    matchToComment EpaBlockComment {} = True
-    matchToComment _ = False
-    constructPragma optionOrPragma xs =
-      "{-# " ++
-      fmap toUpper optionOrPragma ++ " " ++ intercalate ", " xs ++ " #-}"
+  mapMaybe extractPragma . listify isBlockComment . hsmodAnn
+#endif
 
 -- | This function returns a 'Just' value with the pragma
 -- extracted from the passed 'EpaCommentTok' if it has one. Otherwise, it
@@ -59,3 +68,14 @@ extractPragma _ = Nothing
 isPragma :: EpaCommentTok -> Bool
 isPragma (EpaBlockComment c) = match pragmaRegex c
 isPragma _ = False
+
+-- | Construct a pragma.
+constructPragma :: String -> [String] -> String
+constructPragma optionOrPragma xs =
+  "{-# " ++
+  fmap toUpper optionOrPragma ++ " " ++ intercalate ", " xs ++ " #-}"
+
+-- | Checks if the given comment is a block one.
+isBlockComment :: EpaCommentTok -> Bool
+isBlockComment EpaBlockComment {} = True
+isBlockComment _ = False

--- a/src/HIndent/Pretty/Pragma.hs
+++ b/src/HIndent/Pretty/Pragma.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Pretty-printing pragmas
 module HIndent.Pretty.Pragma
   ( prettyPragmas
@@ -18,7 +19,6 @@ import HIndent.Pretty.Combinators.Lineup
 import HIndent.Pretty.Combinators.String
 import HIndent.Printer
 import Text.Regex.TDFA
-
 -- | This function pretty-prints the module's pragmas
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 prettyPragmas :: HsModule GhcPs -> Printer ()
@@ -26,7 +26,6 @@ prettyPragmas :: HsModule GhcPs -> Printer ()
 prettyPragmas :: HsModule -> Printer ()
 #endif
 prettyPragmas = lined . fmap string . collectPragmas
-
 -- | This function returns a 'True' if the module has pragmas.
 -- Otherwise, it returns a 'False'.
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -35,7 +34,6 @@ pragmaExists :: HsModule GhcPs -> Bool
 pragmaExists :: HsModule -> Bool
 #endif
 pragmaExists = not . null . collectPragmas
-
 -- | This function collects pragma comments from the
 -- given module and modifies them into 'String's.
 --
@@ -52,7 +50,6 @@ collectPragmas =
   fmap (uncurry constructPragma) .
   mapMaybe extractPragma . listify isBlockComment . hsmodAnn
 #endif
-
 -- | This function returns a 'Just' value with the pragma
 -- extracted from the passed 'EpaCommentTok' if it has one. Otherwise, it
 -- returns a 'Nothing'.
@@ -72,8 +69,7 @@ isPragma _ = False
 -- | Construct a pragma.
 constructPragma :: String -> [String] -> String
 constructPragma optionOrPragma xs =
-  "{-# " ++
-  fmap toUpper optionOrPragma ++ " " ++ intercalate ", " xs ++ " #-}"
+  "{-# " ++ fmap toUpper optionOrPragma ++ " " ++ intercalate ", " xs ++ " #-}"
 
 -- | Checks if the given comment is a block one.
 isBlockComment :: EpaCommentTok -> Bool

--- a/src/HIndent/Pretty/Pragma.hs
+++ b/src/HIndent/Pretty/Pragma.hs
@@ -20,7 +20,7 @@ import HIndent.Pretty.Combinators.String
 import HIndent.Printer
 import Text.Regex.TDFA
 -- | This function pretty-prints the module's pragmas
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 prettyPragmas :: HsModule GhcPs -> Printer ()
 #else
 prettyPragmas :: HsModule -> Printer ()
@@ -28,7 +28,7 @@ prettyPragmas :: HsModule -> Printer ()
 prettyPragmas = lined . fmap string . collectPragmas
 -- | This function returns a 'True' if the module has pragmas.
 -- Otherwise, it returns a 'False'.
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 pragmaExists :: HsModule GhcPs -> Bool
 #else
 pragmaExists :: HsModule -> Bool
@@ -39,7 +39,7 @@ pragmaExists = not . null . collectPragmas
 --
 -- A pragma's name is converted to the @SHOUT_CASE@ (e.g., @lAnGuAgE@ ->
 -- @LANGUAGE@).
-#if MIN_VERSION_ghc_lib_parser(9,6,1)
+#if GLP961
 collectPragmas :: HsModule GhcPs -> [String]
 collectPragmas =
   fmap (uncurry constructPragma) .

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -295,11 +295,12 @@ data NodeComments = NodeComments
   }
 
 instance Semigroup NodeComments where
-  x <> y = NodeComments{
-    commentsBefore=commentsBefore x<>commentsBefore y,
-    commentsOnSameLine=commentsOnSameLine x<>commentsOnSameLine y,
-    commentsAfter =commentsAfter x<>commentsAfter y
-  }
+  x <> y =
+    NodeComments
+      { commentsBefore = commentsBefore x <> commentsBefore y
+      , commentsOnSameLine = commentsOnSameLine x <> commentsOnSameLine y
+      , commentsAfter = commentsAfter x <> commentsAfter y
+      }
 
 -- | Values indicating whether `do` or `mdo` is used.
 data DoOrMdo

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -294,6 +294,13 @@ data NodeComments = NodeComments
   , commentsAfter :: [LEpaComment]
   }
 
+instance Semigroup NodeComments where
+  x <> y = NodeComments{
+    commentsBefore=commentsBefore x<>commentsBefore y,
+    commentsOnSameLine=commentsOnSameLine x<>commentsOnSameLine y,
+    commentsAfter =commentsAfter x<>commentsAfter y
+  }
+
 -- | Values indicating whether `do` or `mdo` is used.
 data DoOrMdo
   = Do

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -111,7 +111,7 @@ newtype GRHSProc =
 -- | A pattern match against a record.
 newtype RecConPat =
   RecConPat (HsRecFields GhcPs (LPat GhcPs))
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 -- | A record field in a pattern match.
 newtype RecConField =
   RecConField (HsFieldBind (LFieldOcc GhcPs) (LPat GhcPs))
@@ -211,7 +211,7 @@ newtype DeclSig =
 -- | A top-level type family instance declaration.
 newtype TopLevelTyFamInstDecl =
   TopLevelTyFamInstDecl (TyFamInstDecl GhcPs)
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 -- | A wrapper type for type class constraints; e.g., (Eq a, Ord a) of (Eq
 -- a, Ord a) => [a] -> [a]. Either 'HorizontalContext' or 'VerticalContext'
 -- is used internally.
@@ -260,7 +260,7 @@ data LambdaCase = LambdaCase
   { lamCaseGroup :: MatchGroup GhcPs (LHsExpr GhcPs)
   , caseOrCases :: CaseOrCases
   }
-#if GLP941
+#if MIN_VERSION_ghc_lib_parser(9,4,1)
 -- | A deprecation pragma for a module.
 newtype ModuleDeprecatedPragma =
   ModuleDeprecatedPragma (WarningTxt GhcPs)

--- a/src/HIndent/Pretty/Types.hs
+++ b/src/HIndent/Pretty/Types.hs
@@ -111,7 +111,7 @@ newtype GRHSProc =
 -- | A pattern match against a record.
 newtype RecConPat =
   RecConPat (HsRecFields GhcPs (LPat GhcPs))
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 -- | A record field in a pattern match.
 newtype RecConField =
   RecConField (HsFieldBind (LFieldOcc GhcPs) (LPat GhcPs))
@@ -211,7 +211,7 @@ newtype DeclSig =
 -- | A top-level type family instance declaration.
 newtype TopLevelTyFamInstDecl =
   TopLevelTyFamInstDecl (TyFamInstDecl GhcPs)
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 -- | A wrapper type for type class constraints; e.g., (Eq a, Ord a) of (Eq
 -- a, Ord a) => [a] -> [a]. Either 'HorizontalContext' or 'VerticalContext'
 -- is used internally.
@@ -260,7 +260,7 @@ data LambdaCase = LambdaCase
   { lamCaseGroup :: MatchGroup GhcPs (LHsExpr GhcPs)
   , caseOrCases :: CaseOrCases
   }
-#if MIN_VERSION_ghc_lib_parser(9,4,1)
+#if GLP941
 -- | A deprecation pragma for a module.
 newtype ModuleDeprecatedPragma =
   ModuleDeprecatedPragma (WarningTxt GhcPs)

--- a/src/HIndent/macros.h
+++ b/src/HIndent/macros.h
@@ -1,7 +1,0 @@
-#ifndef MACROS
-#define MACROS
-
-#define GLP961 MIN_VERSION_ghc_lib_parser(9,6,1)
-#define GLP941 MIN_VERSION_ghc_lib_parser(9,4,1)
-
-#endif

--- a/src/HIndent/macros.h
+++ b/src/HIndent/macros.h
@@ -1,0 +1,7 @@
+#ifndef MACROS
+#define MACROS
+
+#define GLP961 MIN_VERSION_ghc_lib_parser(9,6,1)
+#define GLP941 MIN_VERSION_ghc_lib_parser(9,4,1)
+
+#endif


### PR DESCRIPTION
- [ ] Create a wrapper for `ghc-lib-parser` to handle different versions easily

Fixes: #697
