### PR TITLE
Fix the misplacement of comments in a do expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Fixed module names being removed from uses of qualified `do` ([#696]).
 - Misplaced haddocks for class declarations ([#706]).
-- Misplaced comments in  do expressions  ([#707]).
+- Misplaced comments in do expressions ([#707]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Fixed module names being removed from uses of qualified `do` ([#696]).
 - Misplaced haddocks for class declarations ([#706]).
-- Misplaced comments in  do expressions 
+- Misplaced comments in  do expressions  ([#707]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed module names being removed from uses of qualified `do` ([#696]).
 - Misplaced haddocks for class declarations ([#706]).
+- Misplaced comments in  do expressions 
 
 ### Removed
 
@@ -339,6 +340,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#707]: https://github.com/mihaimaruseac/hindent/pull/707
 [#706]: https://github.com/mihaimaruseac/hindent/pull/706
 [#699]: https://github.com/mihaimaruseac/hindent/pull/699
 [#696]: https://github.com/mihaimaruseac/hindent/pull/696

--- a/TESTS.md
+++ b/TESTS.md
@@ -3041,15 +3041,12 @@ gamma = do
   -- the very last block is detected differently
 ```
 
-Doesn't work yet (wrong comment position detection)
+Comments in a do expression
 
-```haskell pending
+```haskell
 gamma = do
   -- in the beginning of a do-block
   delta
-  where
-    -- before alpha
-    alpha = alpha
 ```
 
 Comments in a class instance


### PR DESCRIPTION
Fixes: #474 