### PR TITLE
Simplify the internal structure of `Printer`

### DIFF
--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -16,7 +16,6 @@ module HIndent
 import Control.Exception
 import Control.Monad
 import Control.Monad.State.Strict
-import Control.Monad.Trans.Maybe
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import Data.ByteString.Builder (Builder)
@@ -28,7 +27,6 @@ import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.ByteString.Unsafe as S
 import Data.Char
-import Data.Functor.Identity
 import Data.List hiding (stripPrefix)
 import Data.Maybe
 import Data.Version
@@ -205,20 +203,18 @@ runPrinterStyle config m =
   maybe
     (error "Printer failed with mzero call.")
     psOutput
-    (runIdentity
-       (runMaybeT
-          (execStateT
-             (runPrinter m)
-             (PrintState
-                { psIndentLevel = 0
-                , psOutput = mempty
-                , psNewline = False
-                , psColumn = 0
-                , psLine = 1
-                , psConfig = config
-                , psFitOnOneLine = False
-                , psEolComment = False
-                }))))
+    (execStateT
+       (runPrinter m)
+       (PrintState
+          { psIndentLevel = 0
+          , psOutput = mempty
+          , psNewline = False
+          , psColumn = 0
+          , psLine = 1
+          , psConfig = config
+          , psFitOnOneLine = False
+          , psEolComment = False
+          }))
 
 s8_stripPrefix :: ByteString -> ByteString -> Maybe ByteString
 s8_stripPrefix bs1@(S.PS _ _ l1) bs2

--- a/src/HIndent/Printer.hs
+++ b/src/HIndent/Printer.hs
@@ -13,15 +13,13 @@ module HIndent.Printer
 import Control.Applicative
 import Control.Monad
 import Control.Monad.State.Strict (MonadState(..), StateT)
-import Control.Monad.Trans.Maybe
 import Data.ByteString.Builder
-import Data.Functor.Identity
 import Data.Int (Int64)
 import HIndent.Config
 
 -- | A pretty printing monad.
 newtype Printer a = Printer
-  { runPrinter :: StateT PrintState (MaybeT Identity) a
+  { runPrinter :: StateT PrintState Maybe a
   } deriving ( Applicative
              , Monad
              , Functor


### PR DESCRIPTION
### Description of the PR

This PR replaces `MaybeT Identity` inside `Printer` with `Maybe`.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
