### PR TITLE
`reformat` returns a `ParseError` on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - `reformat` now takes a list of `Extension`s instead of a `Maybe` value containing the list ([#712]).
+- `reformat` now returns a `ParseError` on errer ([#715]).
 
 ### Fixed
 
@@ -342,6 +343,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#715]: https://github.com/mihaimaruseac/hindent/pull/715
 [#712]: https://github.com/mihaimaruseac/hindent/pull/712
 [#709]: https://github.com/mihaimaruseac/hindent/pull/709
 [#708]: https://github.com/mihaimaruseac/hindent/pull/708

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 
 - `reformat` now takes a list of `Extension`s instead of a `Maybe` value containing the list ([#712]).
-- `reformat` now returns a `ParseError` on errer ([#715]).
+- `reformat` and `testAst` now returns a `ParseError` on errer ([#715]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 
 - `reformat` now takes a list of `Extension`s instead of a `Maybe` value containing the list ([#712]).
-- `reformat` and `testAst` now returns a `ParseError` on errer ([#715]).
+- `reformat` and `testAst` now returns a `ParseError` on error ([#715]).
 
 ### Fixed
 

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -34,7 +34,7 @@ toCriterion = go
         then (bench
                 (UTF8.toString desc)
                 (nf
-                   (either error S.toLazyByteString .
+                   (either (error . show) S.toLazyByteString .
                     reformat
                       HIndent.Config.defaultConfig
                       defaultExtensions

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -38,6 +38,7 @@ library
       HIndent.CodeBlock
       HIndent.CommandlineOptions
       HIndent.Config
+      HIndent.Error
       HIndent.GhcLibParserWrapper.GHC.Hs
       HIndent.Language
       HIndent.LanguageExtension

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -200,21 +200,20 @@ prettyPrint config m =
 -- | Pretty print the given printable thing.
 runPrinterStyle :: Config -> Printer () -> Builder
 runPrinterStyle config m =
-  maybe
-    (error "Printer failed with mzero call.")
-    psOutput
-    (execStateT
-       (runPrinter m)
-       (PrintState
-          { psIndentLevel = 0
-          , psOutput = mempty
-          , psNewline = False
-          , psColumn = 0
-          , psLine = 1
-          , psConfig = config
-          , psFitOnOneLine = False
-          , psEolComment = False
-          }))
+  maybe (error "Printer failed with mzero call.") psOutput $
+  execStateT (runPrinter m) initState
+  where
+    initState =
+      PrintState
+        { psIndentLevel = 0
+        , psOutput = mempty
+        , psNewline = False
+        , psColumn = 0
+        , psLine = 1
+        , psConfig = config
+        , psFitOnOneLine = False
+        , psEolComment = False
+        }
 
 s8_stripPrefix :: ByteString -> ByteString -> Maybe ByteString
 s8_stripPrefix bs1@(S.PS _ _ l1) bs2

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -128,7 +128,7 @@ reformat config mexts mfilepath =
               let rawErrLoc = psRealLoc $ loc st
                in Left $
                   ParseError
-                    { errorRow = srcLocLine rawErrLoc + yPos
+                    { errorLine = srcLocLine rawErrLoc + yPos
                     , errorCol = srcLocCol rawErrLoc
                     , errorFile = fromMaybe "<interactive>" mfilepath
                     }

--- a/src/HIndent/Error.hs
+++ b/src/HIndent/Error.hs
@@ -8,7 +8,7 @@ module HIndent.Error
 
 -- | Parse error type with the location.
 data ParseError = ParseError
-  { errorRow :: Int -- ^ The row of the parse error's location.
+  { errorLine :: Int -- ^ The row of the parse error's location.
   , errorCol :: Int -- ^ The column of the parse error's location.
   , errorFile :: FilePath -- ^ The filename HIndent failed to parse.
   } deriving (Eq, Ord, Show, Read)
@@ -17,4 +17,4 @@ data ParseError = ParseError
 prettyParseError :: ParseError -> String
 prettyParseError ParseError {..} =
   "Parse failed at (" <>
-  show errorRow <> ", " <> show errorCol <> ") in " <> errorFile <> "."
+  show errorLine <> ", " <> show errorCol <> ") in " <> errorFile <> "."

--- a/src/HIndent/Error.hs
+++ b/src/HIndent/Error.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Error types and functions.
+module HIndent.Error
+  ( ParseError(..)
+  , prettyParseError
+  ) where
+
+-- | Parse error type with the location.
+data ParseError = ParseError
+  { errorRow :: Int -- ^ The row of the parse error's location.
+  , errorCol :: Int -- ^ The column of the parse error's location.
+  , errorFile :: FilePath -- ^ The filename HIndent failed to parse.
+  } deriving (Eq, Ord, Show, Read)
+
+-- | Pretty-print `ParseError`.
+prettyParseError :: ParseError -> String
+prettyParseError ParseError {..} =
+  "Parse failed at (" <>
+  show errorRow <> ", " <> show errorCol <> ") in " <> errorFile <> "."

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -18,6 +18,7 @@ import Data.Version
 import qualified HIndent
 import HIndent.CodeBlock
 import HIndent.Config
+import HIndent.Error
 import HIndent.Internal.Test.Markdone
 import qualified HIndent.LanguageExtension as HIndent
 import qualified System.Info
@@ -37,7 +38,7 @@ main = do
 
 reformat :: Config -> S.ByteString -> ByteString
 reformat cfg code =
-  either (("-- " <>) . L8.pack) S.toLazyByteString $
+  either (("-- " <>) . L8.pack . prettyParseError) S.toLazyByteString $
   HIndent.reformat cfg HIndent.defaultExtensions Nothing code
 
 -- | Convert the Markdone document to Spec benchmarks.


### PR DESCRIPTION
### Description of the PR

Makes `reformat` return a `ParseError` on error. This will let users get the error's detail easily.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
