### PR TITLE
Make `reformat` return a `ByteString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `reformat` now takes a list of `Extension`s instead of a `Maybe` value containing the list ([#712]).
 - `reformat` and `testAst` now returns a `ParseError` on error ([#715]).
+- `reformat` now returns the formatted code as a `ByteString` instead of a `Builder`. ([#720]).
 
 ### Fixed
 
@@ -343,6 +344,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#720]: https://github.com/mihaimaruseac/hindent/pull/720
 [#715]: https://github.com/mihaimaruseac/hindent/pull/715
 [#712]: https://github.com/mihaimaruseac/hindent/pull/712
 [#709]: https://github.com/mihaimaruseac/hindent/pull/709

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -31,15 +31,15 @@ toCriterion = go
       bgroup (S8.unpack name) (go children) : go next
     go (PlainText desc:CodeFence lang code:next) =
       if lang == "haskell"
-        then (bench
-                (UTF8.toString desc)
-                (nf
-                   (either (error . show) S.toLazyByteString .
-                    reformat
-                      HIndent.Config.defaultConfig
-                      defaultExtensions
-                      Nothing)
-                   code)) :
+        then bench
+               (UTF8.toString desc)
+               (nf
+                  (either (error . show) id .
+                   reformat
+                     HIndent.Config.defaultConfig
+                     defaultExtensions
+                     Nothing)
+                  code) :
              go next
         else go next
     go (PlainText {}:next) = go next

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -21,6 +21,7 @@ import qualified Data.ByteString as S
 import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as S
 import qualified Data.ByteString.Char8 as S8
+import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.ByteString.Unsafe as S
 import Data.Char
@@ -120,7 +121,7 @@ reformat config mexts mfilepath =
             POk _ m ->
               Right $
               addPrefix prefix $
-              S.toStrict $ S.toLazyByteString $ prettyPrint config m
+              L.toStrict $ S.toLazyByteString $ prettyPrint config m
             PFailed st ->
               let rawErrLoc = psRealLoc $ loc st
                in Left $

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -38,7 +38,7 @@ main = do
 
 reformat :: Config -> S.ByteString -> ByteString
 reformat cfg code =
-  either (("-- " <>) . L8.pack . prettyParseError) S.toLazyByteString $
+  either (("-- " <>) . L8.pack . prettyParseError) L.fromStrict $
   HIndent.reformat cfg HIndent.defaultExtensions Nothing code
 
 -- | Convert the Markdone document to Spec benchmarks.


### PR DESCRIPTION
### Description of the PR

Makes `reformat` return a `ByteString`.

In the early days, `reformat` simply returned the `Builder` contained in `PrintState`, therefore it was reasonable for the return type of `reformat` to be `Builder`. However, `reformat` started changing `Builder` to `ByteString` once, manipulating it, and then back to `Builder` again, in order to support prefixes and such.  Thus, returning a `Builder` became not very reasonable, and instead, I thought it would be better to simply return the `ByteString` since it would be easier for the user to use it.

I am not familiar with the topic of lazy vs strict. The reason why I made `reformat` return the strict version is that `reformat` accepts the same type of value as an argument. However, since `Builder` can only convert to lazy ByteString, perhaps it is more convenient to return the lazy version.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
