### PR TITLE
Remove the default extensions for HIndent

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -3,6 +3,8 @@
 Bunch of declarations
 
 ``` haskell
+{-# LANGUGAE QuasiQuotes #-}
+
 listPrinters =
   [(''[]
    ,\(typeVariable:_) _automaticPrinter ->
@@ -59,6 +61,8 @@ infixApp :: Exp NodeInfo
 Bunch of declarations - sans comments
 
 ``` haskell
+{-# LANGUGAE QuasiQuotes #-}
+
 listPrinters =
   [(''[]
    ,\(typeVariable:_) _automaticPrinter ->
@@ -116,6 +120,8 @@ infixApp :: Exp NodeInfo
 Quasi-quotes with nested lets and operators
 
 ``` haskell
+{-# LANGUGAE QuasiQuotes #-}
+
 quasiQuotes =
   [(''[]
    ,\(typeVariable:_) _automaticPrinter ->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `reformat` now takes a list of `Extension`s instead of a `Maybe` value containing the list ([#712]).
 - `reformat` and `testAst` now return a `ParseError` on error ([#715]).
 - `reformat` now returns the formatted code as a `ByteString` instead of a `Builder`. ([#720]).
+- HIndent now assumes no extensions are enabled by default ([#728]).
 
 ### Fixed
 
@@ -23,7 +24,8 @@
 
 ### Removed
 
-- ...
+- `HIndent.LanguageExtension.defaultExtensions` ([#728])
+- `HIndent.LanguageExtension.allExtensions` ([#728])
 
 ## [6.0.0] - 2023-02-20
 
@@ -345,6 +347,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#728]: https://github.com/mihaimaruseac/hindent/pull/728
 [#727]: https://github.com/mihaimaruseac/hindent/pull/727
 [#720]: https://github.com/mihaimaruseac/hindent/pull/720
 [#715]: https://github.com/mihaimaruseac/hindent/pull/715

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -34,10 +34,7 @@ toCriterion = go
                (UTF8.toString desc)
                (nf
                   (either (error . show) id .
-                   reformat
-                     HIndent.Config.defaultConfig
-                     defaultExtensions
-                     Nothing)
+                   reformat HIndent.Config.defaultConfig [] Nothing)
                   code) :
              go next
         else go next

--- a/src/HIndent/CabalFile.hs
+++ b/src/HIndent/CabalFile.hs
@@ -21,7 +21,7 @@ import Distribution.PackageDescription.Parsec
 import Distribution.PackageDescription.Parse
 #endif
 import HIndent.Language
-import HIndent.LanguageExtension hiding (defaultExtensions)
+import HIndent.LanguageExtension
 import HIndent.LanguageExtension.Conversion
 import HIndent.LanguageExtension.Types
 import Language.Haskell.Extension hiding (Extension)

--- a/src/HIndent/LanguageExtension.hs
+++ b/src/HIndent/LanguageExtension.hs
@@ -6,8 +6,6 @@ module HIndent.LanguageExtension
   ( implicitExtensions
   , extensionImplies
   , collectLanguageExtensionsFromSource
-  , defaultExtensions
-  , allExtensions
   , getExtensions
   ) where
 
@@ -16,7 +14,6 @@ import Data.List
 import Data.List.Split
 import Data.Maybe
 import qualified GHC.Driver.Session as GLP
-import qualified GHC.LanguageExtensions as GLP
 import HIndent.LanguageExtension.Conversion
 import HIndent.LanguageExtension.Types
 import HIndent.Pragma
@@ -48,7 +45,7 @@ collectLanguageExtensionsFromSource =
 
 -- | Consume an extensions list from arguments.
 getExtensions :: [String] -> [Extension]
-getExtensions = foldr f defaultExtensions
+getExtensions = foldr f []
   where
     f "Haskell98" _ = []
     f x a =
@@ -90,31 +87,3 @@ extractLanguageExtensionsFromOptions options =
 -- | Removes spaces before and after the string.
 stripSpaces :: String -> String
 stripSpaces = reverse . dropWhile isSpace . reverse . dropWhile isSpace
-
--- | Default extensions.
-defaultExtensions :: [Extension]
-defaultExtensions = fmap EnableExtension $ [minBound ..] \\ badExtensions
-
--- | All extensions supported by Cabal.
-allExtensions :: [Extension]
-allExtensions = fmap EnableExtension [minBound ..]
-
--- | Extensions which steal too much syntax.
-badExtensions :: [GLP.Extension]
-badExtensions =
-  [ GLP.Arrows -- steals proc
-  , GLP.TransformListComp -- steals the group keyword
-  , GLP.UnboxedTuples -- breaks (#) lens operator
-  , GLP.UnboxedSums -- Same as 'UnboxedTuples'
-    -- ,QuasiQuotes -- breaks [x| ...], making whitespace free list comps break
-  , GLP.PatternSynonyms -- steals the pattern keyword
-  , GLP.RecursiveDo -- steals the rec keyword
-  , GLP.TypeApplications -- Steals `@`
-  , GLP.StaticPointers -- Steals the `static` keyword
-  , GLP.AlternativeLayoutRule -- Breaks a few tests
-  , GLP.AlternativeLayoutRuleTransitional -- Same as `AlternativeLayoutRule`
-  , GLP.LexicalNegation -- Cannot handle minus signs in some cases
-  , GLP.OverloadedRecordDot -- Breaks 'a.b'
-  , GLP.OverloadedRecordUpdate -- Cannot handle symbol members starting
-                               -- with a dot in a record well
-  ]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -20,7 +20,6 @@ import HIndent.CodeBlock
 import HIndent.Config
 import HIndent.Error
 import HIndent.Internal.Test.Markdone
-import qualified HIndent.LanguageExtension as HIndent
 import qualified System.Info
 import Test.Hspec
 import Text.Read


### PR DESCRIPTION
### Description of the PR

Removes `HIndent.LanguageExtension.defaultExtensions` and `HIndent.LanguageExtension.allExtensions`.

Now that HIndent can collect extensions from source codes, a cabal file,
and command line parameters, they are no longer needed.


### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
