### PR TITLE
Export only the `HIndent` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `reformat` and `testAst` now return a `ParseError` on error ([#715]).
 - `reformat` now returns the formatted code as a `ByteString` instead of a `Builder`. ([#720]).
 - HIndent now assumes no extensions are enabled by default ([#728]).
+- All modules except for `HIndent` are now private, and the minimum necessary definitions are exposed from the module ([#729]).
 
 ### Fixed
 
@@ -347,6 +348,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#729]: https://github.com/mihaimaruseac/hindent/pull/729
 [#728]: https://github.com/mihaimaruseac/hindent/pull/728
 [#727]: https://github.com/mihaimaruseac/hindent/pull/727
 [#720]: https://github.com/mihaimaruseac/hindent/pull/720

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -11,9 +11,7 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.UTF8 as UTF8
 import HIndent
-import HIndent.Config
 import HIndent.Internal.Test.Markdone
-import HIndent.LanguageExtension
 
 -- | Main benchmarks.
 main :: IO ()
@@ -34,7 +32,7 @@ toCriterion = go
                (UTF8.toString desc)
                (nf
                   (either (error . show) id .
-                   reformat HIndent.Config.defaultConfig [] Nothing)
+                   reformat HIndent.defaultConfig [] Nothing)
                   code) :
              go next
         else go next

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -33,6 +33,7 @@ source-repository head
 library
   exposed-modules:
       HIndent
+  other-modules:
       HIndent.Applicative
       HIndent.CabalFile
       HIndent.CodeBlock
@@ -68,7 +69,6 @@ library
       HIndent.Pretty.SigBindFamily
       HIndent.Pretty.Types
       HIndent.Printer
-  other-modules:
       Paths_hindent
   autogen-modules:
       Paths_hindent

--- a/package.yaml
+++ b/package.yaml
@@ -60,6 +60,8 @@ when:
 
 library:
   source-dirs: src
+  exposed-modules:
+    - HIndent
 
 internal-libraries:
   hindent-internal:

--- a/src/HIndent.hs
+++ b/src/HIndent.hs
@@ -5,12 +5,22 @@
 
 -- | Haskell indenter.
 module HIndent
-  ( hindent
+  ( -- * The entry point.
+    hindent
   , -- * Formatting functions.
     reformat
-  , prettyPrint
+  , -- * Config
+    Config(..)
+  , defaultConfig
+  , getConfig
+  , -- * Extension
+    Extension(..)
+  , -- * Error
+    ParseError(..)
+  , prettyParseError
   , -- * Testing
     testAst
+  , HsModule'
   ) where
 
 import Control.Exception

--- a/src/HIndent/GhcLibParserWrapper/GHC/Hs.hs
+++ b/src/HIndent/GhcLibParserWrapper/GHC/Hs.hs
@@ -7,7 +7,7 @@ module HIndent.GhcLibParserWrapper.GHC.Hs
   ) where
 
 import GHC.Hs
--- | The wrapper for `HsModule'`
+-- | The wrapper for `HsModule`
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 type HsModule' = HsModule GhcPs
 #else

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -7,7 +7,6 @@ module Main where
 import Data.Algorithm.Diff
 import Data.Algorithm.DiffOutput
 import qualified Data.ByteString as S
-import qualified Data.ByteString.Builder as S
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as L8
@@ -16,9 +15,7 @@ import qualified Data.ByteString.UTF8 as UTF8
 import Data.Function
 import Data.Version
 import qualified HIndent
-import HIndent.CodeBlock
-import HIndent.Config
-import HIndent.Error
+import HIndent (Config(..))
 import HIndent.Internal.Test.Markdone
 import qualified System.Info
 import Test.Hspec
@@ -31,20 +28,19 @@ main = do
   bytes <- S.readFile "TESTS.md"
   forest <- parse (tokenize bytes)
   hspec $ do
-    codeBlocksSpec
     markdoneSpec
     toSpec forest
 
 reformat :: Config -> S.ByteString -> ByteString
 reformat cfg code =
-  either (("-- " <>) . L8.pack . prettyParseError) L.fromStrict $
+  either (("-- " <>) . L8.pack . HIndent.prettyParseError) L.fromStrict $
   HIndent.reformat cfg [] Nothing code
 
 -- | Convert the Markdone document to Spec benchmarks.
 toSpec :: [Markdone] -> Spec
 toSpec = go
   where
-    cfg = HIndent.Config.defaultConfig {configTrailingNewline = False}
+    cfg = HIndent.defaultConfig {configTrailingNewline = False}
     go (Section name children:next) = do
       describe (UTF8.toString name) (go children)
       go next
@@ -131,39 +127,6 @@ diff x y = ppDiff (on getGroupedDiff (lines . LUTF8.toString) x y)
 skipEmptyLines :: [Markdone] -> [Markdone]
 skipEmptyLines (PlainText "":rest) = rest
 skipEmptyLines other = other
-
-codeBlocksSpec :: Spec
-codeBlocksSpec =
-  describe "splitting source into code blocks" $ do
-    it "should put just Haskell code in its own block" $ do
-      let input = "this is totally haskell code\n\nit deserves its own block!\n"
-      cppSplitBlocks input `shouldBe` [HaskellSource 0 input]
-    it "should put #if/#endif and Haskell code into separate blocks" $ do
-      cppSplitBlocks
-        "haskell code\n#if DEBUG\ndebug code\n#endif\nmore haskell code\n" `shouldBe`
-        [ HaskellSource 0 "haskell code"
-        , CPPDirectives "#if DEBUG"
-        , HaskellSource 2 "debug code"
-        , CPPDirectives "#endif"
-        , HaskellSource 4 "more haskell code\n"
-        ]
-    it "should put the shebang line into its own block" $ do
-      cppSplitBlocks
-        "#!/usr/bin/env runhaskell\n{-# LANGUAGE OverloadedStrings #-}\n" `shouldBe`
-        [ Shebang "#!/usr/bin/env runhaskell"
-        , HaskellSource 1 "{-# LANGUAGE OverloadedStrings #-}\n"
-        ]
-    it "should put a multi-line #define into its own block" $ do
-      let input = "#define A \\\n  macro contents \\\n  go here\nhaskell code\n"
-      cppSplitBlocks input `shouldBe`
-        [ CPPDirectives "#define A \\\n  macro contents \\\n  go here"
-        , HaskellSource 3 "haskell code\n"
-        ]
-    it "should put an unterminated multi-line #define into its own block" $ do
-      cppSplitBlocks "#define A \\" `shouldBe` [CPPDirectives "#define A \\"]
-      cppSplitBlocks "#define A \\\n" `shouldBe` [CPPDirectives "#define A \\"]
-      cppSplitBlocks "#define A \\\n.\\" `shouldBe`
-        [CPPDirectives "#define A \\\n.\\"]
 
 markdoneSpec :: Spec
 markdoneSpec = do


### PR DESCRIPTION
### Description of the PR

Exports only the `HIndent` module to hide the implementation.

I removed `cppBlocksSpec` as it is covered by tests using TESTS.md.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
