### PR TITLE
Fix the default config written in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Changed
 
 ### Fixed
-- Wrong default HIndent configuration in README.md ([#750]).
+- Wrong default HIndent configuration in [`README.md`] ([#750]).
 
 ### Removed
 
@@ -409,5 +409,6 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 
 [`TESTS.md`]: TESTS.md
 [`BENCHMARKS.md`]: BENCHMARKS.md
+[`README.md`]: README.md
 
 [Johan Tibell's Haskell Style Guide]: https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- Wrong default HIndent configuration in README.md ([#750]).
 
 ### Removed
 
@@ -362,6 +363,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#750]: https://github.com/mihaimaruseac/hindent/pull/750
 [#742]: https://github.com/mihaimaruseac/hindent/pull/742
 [#741]: https://github.com/mihaimaruseac/hindent/pull/741
 [#739]: https://github.com/mihaimaruseac/hindent/pull/739

--- a/README.md
+++ b/README.md
@@ -56,11 +56,9 @@ default:
 indent-size: 2
 line-length: 80
 force-trailing-newline: true
-line-breaks: [":>", ":<|>"]
-extensions:
-  - DataKinds
-  - GADTs
-  - TypeApplications
+sort-imports: true
+line-breaks: []
+extensions: []
 ```
 
 By default, hindent preserves the newline or lack of newline in your input. With `force-trailing-newline`, it will make sure there is always a trailing newline.


### PR DESCRIPTION
### Description of the PR

Fixes the HIndent default configuration written in README.md.

### Checklist

- [ ] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
