### PR TITLE
Get pragmas from a `EpaCommentTok`, not a `String`

### DIFF
--- a/src/HIndent/Ast/FileHeaderPragma.hs
+++ b/src/HIndent/Ast/FileHeaderPragma.hs
@@ -3,10 +3,16 @@ module HIndent.Ast.FileHeaderPragma
   , mkFileHeaderPragma
   ) where
 
-import HIndent.Ast.NodeComments
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           Data.Bifunctor
+import           Data.Char
+import           Data.List
+import           Data.List.Split
+import qualified GHC.Hs                      as GHC
+import           HIndent.Ast.NodeComments
+import           HIndent.Pragma
+import           HIndent.Pretty
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 newtype FileHeaderPragma =
   FileHeaderPragma String
@@ -17,5 +23,21 @@ instance CommentExtraction FileHeaderPragma where
 instance Pretty FileHeaderPragma where
   pretty' (FileHeaderPragma x) = string x
 
-mkFileHeaderPragma :: String -> FileHeaderPragma
-mkFileHeaderPragma = FileHeaderPragma
+mkFileHeaderPragma :: GHC.EpaCommentTok -> Maybe FileHeaderPragma
+mkFileHeaderPragma =
+  fmap (FileHeaderPragma . uncurry constructPragma) . extractPragma
+
+-- | This function returns a 'Just' value with the pragma
+-- extracted from the passed 'EpaCommentTok' if it has one. Otherwise, it
+-- returns a 'Nothing'.
+extractPragma :: GHC.EpaCommentTok -> Maybe (String, [String])
+extractPragma (GHC.EpaBlockComment c) =
+  second (fmap strip . splitOn ",") <$> extractPragmaNameAndElement c
+  where
+    strip = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+extractPragma _ = Nothing
+
+-- | Construct a pragma.
+constructPragma :: String -> [String] -> String
+constructPragma optionOrPragma xs =
+  "{-# " ++ fmap toUpper optionOrPragma ++ " " ++ intercalate ", " xs ++ " #-}"

--- a/src/HIndent/Ast/FileHeaderPragma.hs
+++ b/src/HIndent/Ast/FileHeaderPragma.hs
@@ -3,16 +3,16 @@ module HIndent.Ast.FileHeaderPragma
   , mkFileHeaderPragma
   ) where
 
-import           Data.Bifunctor
-import           Data.Char
-import           Data.List
-import           Data.List.Split
-import qualified GHC.Hs                      as GHC
-import           HIndent.Ast.NodeComments
-import           HIndent.Pragma
-import           HIndent.Pretty
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import Data.Bifunctor
+import Data.Char
+import Data.List
+import Data.List.Split
+import qualified GHC.Hs as GHC
+import HIndent.Ast.NodeComments
+import HIndent.Pragma
+import HIndent.Pretty
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 
 newtype FileHeaderPragma =
   FileHeaderPragma String

--- a/src/HIndent/Ast/FileHeaderPragma/Collection.hs
+++ b/src/HIndent/Ast/FileHeaderPragma/Collection.hs
@@ -6,14 +6,14 @@ module HIndent.Ast.FileHeaderPragma.Collection
   , hasPragmas
   ) where
 
-import           Data.Maybe
-import           Generics.SYB
-import           HIndent.Ast.FileHeaderPragma
-import           HIndent.Ast.NodeComments
+import Data.Maybe
+import Generics.SYB
+import HIndent.Ast.FileHeaderPragma
+import HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import           HIndent.Pretty
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
+import HIndent.Pretty
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
 
 newtype FileHeaderPragmaCollection =
   FileHeaderPragmaCollection [FileHeaderPragma]
@@ -26,8 +26,9 @@ instance Pretty FileHeaderPragmaCollection where
 
 mkFileHeaderPragmaCollection :: GHC.HsModule' -> FileHeaderPragmaCollection
 mkFileHeaderPragmaCollection =
-  FileHeaderPragmaCollection .
-  mapMaybe mkFileHeaderPragma . collectBlockComments
+  FileHeaderPragmaCollection
+    . mapMaybe mkFileHeaderPragma
+    . collectBlockComments
 
 hasPragmas :: FileHeaderPragmaCollection -> Bool
 hasPragmas (FileHeaderPragmaCollection xs) = not $ null xs
@@ -38,4 +39,4 @@ collectBlockComments = listify isBlockComment . GHC.getModuleAnn
 -- | Checks if the given comment is a block one.
 isBlockComment :: GHC.EpaCommentTok -> Bool
 isBlockComment GHC.EpaBlockComment {} = True
-isBlockComment _                      = False
+isBlockComment _ = False

--- a/src/HIndent/Ast/FileHeaderPragma/Collection.hs
+++ b/src/HIndent/Ast/FileHeaderPragma/Collection.hs
@@ -6,19 +6,14 @@ module HIndent.Ast.FileHeaderPragma.Collection
   , hasPragmas
   ) where
 
-import Data.Bifunctor
-import Data.Char
-import Data.List
-import Data.List.Split
-import Data.Maybe
-import Generics.SYB
-import HIndent.Ast.FileHeaderPragma
-import HIndent.Ast.NodeComments
+import           Data.Maybe
+import           Generics.SYB
+import           HIndent.Ast.FileHeaderPragma
+import           HIndent.Ast.NodeComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
-import HIndent.Pragma
-import HIndent.Pretty
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
+import           HIndent.Pretty
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
 
 newtype FileHeaderPragmaCollection =
   FileHeaderPragmaCollection [FileHeaderPragma]
@@ -31,39 +26,16 @@ instance Pretty FileHeaderPragmaCollection where
 
 mkFileHeaderPragmaCollection :: GHC.HsModule' -> FileHeaderPragmaCollection
 mkFileHeaderPragmaCollection =
-  FileHeaderPragmaCollection . fmap mkFileHeaderPragma . collectPragmas
+  FileHeaderPragmaCollection .
+  mapMaybe mkFileHeaderPragma . collectBlockComments
 
 hasPragmas :: FileHeaderPragmaCollection -> Bool
 hasPragmas (FileHeaderPragmaCollection xs) = not $ null xs
 
--- | This function collects pragma comments from the
--- given module and modifies them into 'String's.
---
--- A pragma's name is converted to the @SHOUT_CASE@ (e.g., @lAnGuAgE@ ->
--- @LANGUAGE@).
-collectPragmas :: GHC.HsModule' -> [String]
-collectPragmas =
-  fmap (uncurry constructPragma)
-    . mapMaybe extractPragma
-    . listify isBlockComment
-    . GHC.getModuleAnn
-
--- | This function returns a 'Just' value with the pragma
--- extracted from the passed 'EpaCommentTok' if it has one. Otherwise, it
--- returns a 'Nothing'.
-extractPragma :: GHC.EpaCommentTok -> Maybe (String, [String])
-extractPragma (GHC.EpaBlockComment c) =
-  second (fmap strip . splitOn ",") <$> extractPragmaNameAndElement c
-  where
-    strip = reverse . dropWhile isSpace . reverse . dropWhile isSpace
-extractPragma _ = Nothing
-
--- | Construct a pragma.
-constructPragma :: String -> [String] -> String
-constructPragma optionOrPragma xs =
-  "{-# " ++ fmap toUpper optionOrPragma ++ " " ++ intercalate ", " xs ++ " #-}"
+collectBlockComments :: GHC.HsModule' -> [GHC.EpaCommentTok]
+collectBlockComments = listify isBlockComment . GHC.getModuleAnn
 
 -- | Checks if the given comment is a block one.
 isBlockComment :: GHC.EpaCommentTok -> Bool
 isBlockComment GHC.EpaBlockComment {} = True
-isBlockComment _ = False
+isBlockComment _                      = False


### PR DESCRIPTION
### Description of the PR

`mkFileHeaderPragma` now takes a `EpaCommentTok` instead of a `String`.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
