### PR TITLE
Fix the pretty-printing of module-level warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Wrong default HIndent configuration in [`README.md`] ([#750]).
 - Fix the bug of panicking when the given source code has CPP lines and space-prefixed lines ([#780]).
 - Fix not pretty-printing multiple signatures in a `SPECIALISE` ([#784]).
-- Fix the bug of not pretty-printing multiple module-level warnings ([#822])
+- Fix the bug of not pretty-printing multiple module-level warning messages ([#822])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Wrong default HIndent configuration in [`README.md`] ([#750]).
 - Fix the bug of panicking when the given source code has CPP lines and space-prefixed lines ([#780]).
 - Fix not pretty-printing multiple signatures in a `SPECIALISE` ([#784]).
+- Fix the bug of not pretty-printing multiple module-level warnings ([#822])
 
 ### Removed
 
@@ -368,6 +369,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#822]: https://github.com/mihaimaruseac/hindent/pull/822
 [#784]: https://github.com/mihaimaruseac/hindent/pull/784
 [#780]: https://github.com/mihaimaruseac/hindent/pull/780
 [#775]: https://github.com/mihaimaruseac/hindent/pull/775

--- a/TESTS.md
+++ b/TESTS.md
@@ -205,6 +205,16 @@ module Foo {-# DEPRECATED "Use Bar." #-}
   ) where
 ```
 
+With a list of reasons and an export list.
+
+```haskell
+module Foo {-# DEPRECATED ["Use Bar.", "Or use Baz."] #-}
+  ( x
+  , y
+  , z
+  ) where
+```
+
 ## Imports, foreign imports, and foreign exports
 
 Import lists

--- a/TESTS.md
+++ b/TESTS.md
@@ -179,13 +179,19 @@ static = 3
 
 #### `WARNING`
 
-A `WARNING` for a module without an export list.
+Without messages and an export list.
+
+```haskell
+module Foo {-# WARNING [] #-} where
+```
+
+With a string without an export list.
 
 ```haskell
 module Foo {-# WARNING "Debug purpose only." #-} where
 ```
 
-A `WARNING` for a module with a list of reasons without an export list.
+With a list of reasons without an export list.
 
 ```haskell
 module Foo {-# WARNING ["Debug purpose only.", "Okay?"] #-} where

--- a/TESTS.md
+++ b/TESTS.md
@@ -195,14 +195,10 @@ Without messages and an export list.
 module Foo {-# DEPRECATED [] #-} where
 ```
 
-With a string and an export list.
+With a string without an export list.
 
 ```haskell
-module Foo {-# DEPRECATED "Use Bar." #-}
-  ( x
-  , y
-  , z
-  ) where
+module Foo {-# DEPRECATED "Use Bar." #-} where
 ```
 
 With a list of reasons and an export list.

--- a/TESTS.md
+++ b/TESTS.md
@@ -77,16 +77,6 @@ module X
 
 ### Module-level pragmas
 
-A `DEPRECATED` for a module with an export list.
-
-```haskell
-module Foo {-# DEPRECATED "Use Bar." #-}
-  ( x
-  , y
-  , z
-  ) where
-```
-
 A pragma's name is converted to the SHOUT_CASE.
 
 ```haskell given
@@ -195,6 +185,18 @@ With a list of reasons without an export list.
 
 ```haskell
 module Foo {-# WARNING ["Debug purpose only.", "Okay?"] #-} where
+```
+
+#### `DEPRECATED`
+
+With a string and an export list.
+
+```haskell
+module Foo {-# DEPRECATED "Use Bar." #-}
+  ( x
+  , y
+  , z
+  ) where
 ```
 
 ## Imports, foreign imports, and foreign exports

--- a/TESTS.md
+++ b/TESTS.md
@@ -77,18 +77,6 @@ module X
 
 ### Module-level pragmas
 
-A `WARNING` for a module without an export list.
-
-```haskell
-module Foo {-# WARNING "Debug purpose only." #-} where
-```
-
-A `WARNING` for a module with a list of reasons without an export list.
-
-```haskell
-module Foo {-# WARNING ["Debug purpose only.", "Okay?"] #-} where
-```
-
 A `DEPRECATED` for a module with an export list.
 
 ```haskell
@@ -187,6 +175,20 @@ Do not collect pragma-like comments
 -- @static@ is no longer a valid identifier
 -- once `StaticPointers` is enabled.
 static = 3
+```
+
+#### `WARNING`
+
+A `WARNING` for a module without an export list.
+
+```haskell
+module Foo {-# WARNING "Debug purpose only." #-} where
+```
+
+A `WARNING` for a module with a list of reasons without an export list.
+
+```haskell
+module Foo {-# WARNING ["Debug purpose only.", "Okay?"] #-} where
 ```
 
 ## Imports, foreign imports, and foreign exports

--- a/TESTS.md
+++ b/TESTS.md
@@ -189,6 +189,12 @@ module Foo {-# WARNING ["Debug purpose only.", "Okay?"] #-} where
 
 #### `DEPRECATED`
 
+Without messages and an export list.
+
+```haskell
+module Foo {-# DEPRECATED [] #-} where
+```
+
 With a string and an export list.
 
 ```haskell

--- a/TESTS.md
+++ b/TESTS.md
@@ -83,6 +83,12 @@ A `WARNING` for a module without an export list.
 module Foo {-# WARNING "Debug purpose only." #-} where
 ```
 
+A `WARNING` for a module with a list of reasons without an export list.
+
+```haskell
+module Foo {-# WARNING ["Debug purpose only.", "Okay?"] #-} where
+```
+
 A `DEPRECATED` for a module with an export list.
 
 ```haskell

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Pretty printing.
 --
@@ -21,45 +21,45 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import           Control.Monad
-import           Control.Monad.RWS
-import           Data.Maybe
-import           Data.Void
-import           GHC.Core.Coercion
-import           GHC.Core.InstEnv
-import           GHC.Data.Bag
-import           GHC.Data.BooleanFormula
-import           GHC.Data.FastString
-import           GHC.Hs
-import           GHC.Stack
-import           GHC.Types.Basic
-import           GHC.Types.Fixity
-import           GHC.Types.ForeignCall
-import           GHC.Types.Name
-import           GHC.Types.Name.Reader
-import           GHC.Types.SourceText
-import           GHC.Types.SrcLoc
-import           GHC.Unit.Module.Warnings
-import           HIndent.Applicative
-import           HIndent.Ast.NodeComments
-import           HIndent.Config
-import           HIndent.Fixity
-import           HIndent.Pretty.Combinators
-import           HIndent.Pretty.NodeComments
-import           HIndent.Pretty.SigBindFamily
-import           HIndent.Pretty.Types
-import           HIndent.Printer
-import           Language.Haskell.GhclibParserEx.GHC.Hs.Expr
-import           Text.Show.Unicode
+import Control.Monad
+import Control.Monad.RWS
+import Data.Maybe
+import Data.Void
+import GHC.Core.Coercion
+import GHC.Core.InstEnv
+import GHC.Data.Bag
+import GHC.Data.BooleanFormula
+import GHC.Data.FastString
+import GHC.Hs
+import GHC.Stack
+import GHC.Types.Basic
+import GHC.Types.Fixity
+import GHC.Types.ForeignCall
+import GHC.Types.Name
+import GHC.Types.Name.Reader
+import GHC.Types.SourceText
+import GHC.Types.SrcLoc
+import GHC.Unit.Module.Warnings
+import HIndent.Applicative
+import HIndent.Ast.NodeComments
+import HIndent.Config
+import HIndent.Fixity
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+import HIndent.Pretty.SigBindFamily
+import HIndent.Pretty.Types
+import HIndent.Printer
+import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
+import Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable                               as NonEmpty
-import           GHC.Core.DataCon
+import qualified Data.Foldable as NonEmpty
+import GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import           GHC.Unit
+import GHC.Unit
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-import           GHC.Types.PkgQual
+import GHC.Types.PkgQual
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -93,8 +93,10 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c) $
-         spaced $ fmap pretty $ c : cs
+           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c)
+           $ spaced
+           $ fmap pretty
+           $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -130,19 +132,19 @@ instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
 instance Pretty (HsDecl GhcPs) where
-  pretty' (TyClD _ d)      = pretty d
-  pretty' (InstD _ inst)   = pretty inst
-  pretty' (DerivD _ x)     = pretty x
-  pretty' (ValD _ bind)    = pretty bind
-  pretty' (SigD _ s)       = pretty s
-  pretty' (KindSigD _ x)   = pretty x
-  pretty' (DefD _ x)       = pretty x
-  pretty' (ForD _ x)       = pretty x
-  pretty' (WarningD _ x)   = pretty x
-  pretty' (AnnD _ x)       = pretty x
-  pretty' (RuleD _ x)      = pretty x
-  pretty' (SpliceD _ sp)   = pretty sp
-  pretty' DocD {}          = docNode
+  pretty' (TyClD _ d) = pretty d
+  pretty' (InstD _ inst) = pretty inst
+  pretty' (DerivD _ x) = pretty x
+  pretty' (ValD _ bind) = pretty bind
+  pretty' (SigD _ s) = pretty s
+  pretty' (KindSigD _ x) = pretty x
+  pretty' (DefD _ x) = pretty x
+  pretty' (ForD _ x) = pretty x
+  pretty' (WarningD _ x) = pretty x
+  pretty' (AnnD _ x) = pretty x
+  pretty' (RuleD _ x) = pretty x
+  pretty' (SpliceD _ sp) = pretty sp
+  pretty' DocD {} = docNode
   pretty' (RoleAnnotD _ x) = pretty x
 
 instance Pretty (TyClDecl GhcPs) where
@@ -180,7 +182,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_cons tcdDataDefn of
         DataTypeCons {} -> string "data "
-        NewTypeCon {}   -> string "newtype "
+        NewTypeCon {} -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -195,7 +197,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType  -> string "newtype "
+        NewType -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -210,7 +212,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType  -> string "newtype "
+        NewType -> string "newtype "
 #endif
 prettyTyClDecl ClassDecl {..} = do
   if isJust tcdCtxt
@@ -231,20 +233,21 @@ prettyTyClDecl ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            []  -> string "()"
+            [] -> string "()"
             [x] -> pretty x
-            xs  -> hvTuple $ fmap pretty xs
+            xs -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock $
-          string "| " |=>
-          vCommaSep
-            (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
-               printCommentsAnd x $ \(FunDep _ from to) ->
-                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock
+          $ string "| "
+              |=> vCommaSep
+                    (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
+                       printCommentsAnd x $ \(FunDep _ from to) ->
+                         spaced
+                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -255,27 +258,27 @@ prettyTyClDecl ClassDecl {..} = do
         Infix ->
           case hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens $
-                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens
+                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs [] []
 
 instance Pretty (InstDecl GhcPs) where
-  pretty' ClsInstD {..}     = pretty cid_inst
+  pretty' ClsInstD {..} = pretty cid_inst
   pretty' DataFamInstD {..} = pretty dfid_inst
-  pretty' TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (HsBind GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: HsBind GhcPs -> Printer ()
-prettyHsBind FunBind {..}     = pretty fun_matches
-prettyHsBind PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind VarBind {}       = notGeneratedByParser
+prettyHsBind FunBind {..} = pretty fun_matches
+prettyHsBind PatBind {..} = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind VarBind {} = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind AbsBinds {}      = notGeneratedByParser
+prettyHsBind AbsBinds {} = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -295,9 +298,10 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -317,9 +321,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -362,9 +366,10 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock $
-              indentedWithSpace 3 $
-              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock
+              $ indentedWithSpace 3
+              $ pretty
+              $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -384,9 +389,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock $
-          indentedWithSpace 3 $
-          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock
+          $ indentedWithSpace 3
+          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' IdSig {} = notGeneratedByParser
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
@@ -445,12 +450,12 @@ instance Pretty (HsDataDefn GhcPs) where
     where
       cons =
         case dd_cons of
-          NewTypeCon x      -> [x]
+          NewTypeCon x -> [x]
           DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (DataTypeCons _ (L _ ConDeclGADT {}:_)) -> True
-          _                                       -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -486,7 +491,7 @@ instance Pretty (HsDataDefn GhcPs) where
       isGADT =
         case dd_cons of
           (L _ ConDeclGADT {}:_) -> True
-          _                      -> False
+          _ -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -497,8 +502,8 @@ instance Pretty (ClsInstDecl GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
-        unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
+        |=> unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -544,17 +549,18 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              []         -> error "Invalid function application."
+              [] -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col' - col -
-            if col == 0
-              then spaces
-              else 0
+            col'
+              - col
+              - if col == 0
+                  then spaces
+                  else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -592,11 +598,11 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens $
-      prefixedLined "," $
-      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens
+        $ prefixedLined ","
+        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing Missing {} = True
-    isMissing _          = False
+    isMissing _ = False
 prettyHsExpr (ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -621,9 +627,9 @@ prettyHsExpr (HsIf _ cond t f) = do
     branch :: String -> LHsExpr GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (HsDo _ (DoExpr m) xs))  -> doStmt (QualifiedDo m Do) xs
+        (L _ (HsDo _ (DoExpr m) xs)) -> doStmt (QualifiedDo m Do) xs
         (L _ (HsDo _ (MDoExpr m) xs)) -> doStmt (QualifiedDo m Mdo) xs
-        _                             -> string str |=> pretty e
+        _ -> string str |=> pretty e
       where
         doStmt qDo stmts = do
           string str
@@ -631,8 +637,8 @@ prettyHsExpr (HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (HsMultiIf _ guards) =
-  string "if " |=>
-  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if "
+    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -695,9 +701,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsFieldBind a b)]
@@ -725,9 +731,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock $
-        either printHorFields printHorFields fields <-|>
-        either printVerFields printVerFields fields
+      indentedBlock
+        $ either printHorFields printHorFields fields
+            <-|> either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsRecField' a b)]
@@ -754,10 +760,11 @@ prettyHsExpr (HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr HsProjection {..} =
-  parens $
-  forM_ proj_flds $ \x -> do
-    string "."
-    pretty x
+  parens
+    $ forM_ proj_flds
+    $ \x -> do
+        string "."
+        pretty x
 prettyHsExpr (ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -769,8 +776,8 @@ prettyHsExpr (HsSpliceE _ x) = pretty x
 prettyHsExpr (HsProc _ pat x@(L _ (HsCmdTop _ (L _ (HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock $
-    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock
+    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -804,7 +811,7 @@ prettyHsExpr (HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case  -> string "\\case"
+      Case -> string "\\case"
       Cases -> string "\\cases"
     if null $ unLoc $ mg_alts matches
       then string " {}"
@@ -831,10 +838,12 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do hor <-|> ver
-                     newline
-                     prefixed "=> " $
-                       prefixedLined "-> " $ pretty <$> flatten hst_body
+               in do
+                    hor <-|> ver
+                    newline
+                    prefixed "=> "
+                      $ prefixedLined "-> "
+                      $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -844,7 +853,7 @@ instance Pretty HsSigType' where
     where
       flatten :: LHsType GhcPs -> [LHsType GhcPs]
       flatten (L _ (HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x                       = [x]
+      flatten x = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig HsSig {..}) =
     case sig_bndrs of
       HsOuterExplicit _ xs -> do
@@ -853,8 +862,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
-              (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt))
+              <-|> (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -884,10 +893,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -898,19 +907,19 @@ prettyConDecl ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
     forallNeeded =
@@ -928,10 +937,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx)  -> withForallCtx ctx
-        (True, Nothing)   -> withForallOnly
+        (True, Just ctx) -> withForallCtx ctx
+        (True, Nothing) -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing)  -> noForallCtx
+        (False, Nothing) -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -942,52 +951,52 @@ prettyConDecl ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
-      (pretty (Context ctx) >> prefixed "=> " verArgs)
-
+      (pretty (Context ctx) >> string " => " >> horArgs)
+        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt)) <-|>
-        (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt))
+        <-|> (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-
+    
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
-      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
+        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+    
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ") $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ")
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-
+    
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> " $
-          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> "
+            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-
+    
     forallNeeded =
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
@@ -995,26 +1004,30 @@ prettyConDecl ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \c -> do
-        pretty $ Context c
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \c -> do
+             pretty $ Context c
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #else
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do string "forall "
-      spaced $ fmap pretty con_ex_tvs
-      string ". ") |=>
-  (do whenJust con_mb_cxt $ \_ -> do
-        pretty $ Context con_mb_cxt
-        string " =>"
-        newline
-      pretty con_name
-      pretty con_args)
+  (do
+     string "forall "
+     spaced $ fmap pretty con_ex_tvs
+     string ". ")
+    |=> (do
+           whenJust con_mb_cxt $ \_ -> do
+             pretty $ Context con_mb_cxt
+             string " =>"
+             newline
+           pretty con_name
+           pretty con_args)
 #endif
 prettyConDecl ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1030,11 +1043,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
 prettyMatchExpr :: Match GhcPs (LHsExpr GhcPs) -> Printer ()
 prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case unLoc $ head m_pats of
-      LazyPat {} -> space
-      BangPat {} -> space
-      _          -> return ()
+  unless (null m_pats)
+    $ case unLoc $ head m_pats of
+        LazyPat {} -> space
+        BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
@@ -1054,8 +1067,9 @@ prettyMatchExpr Match {..} =
     Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, FunRhs {..}) -> do
-          spaced $
-            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
+          spaced
+            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
+                ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1065,11 +1079,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
 prettyMatchProc :: Match GhcPs (LHsCmd GhcPs) -> Printer ()
 prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats) $
-    case unLoc $ head m_pats of
-      LazyPat {} -> space
-      BangPat {} -> space
-      _          -> return ()
+  unless (null m_pats)
+    $ case unLoc $ head m_pats of
+        LazyPat {} -> space
+        BangPat {} -> space
+        _ -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1129,7 +1143,7 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
     where
       horizontal =
         case rec_dotdot of
-          Just _  -> braces $ string ".."
+          Just _ -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1138,8 +1152,8 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) wher
   pretty' HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (HsType GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1244,7 +1258,7 @@ prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _  -> hvPromotedList $ fmap pretty xs
+    _ -> hvPromotedList $ fmap pretty xs
 prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (HsTyLit _ x) = pretty x
 prettyHsType HsWildCardTy {} = string "_"
@@ -1262,11 +1276,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (HsValBinds epa lr, _) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
@@ -1274,31 +1288,31 @@ instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (HsValBinds epa lr) ->
-        indentedWithSpace 2 $
-        newlinePrefixed
-          [ string "where"
-          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-          ]
+        indentedWithSpace 2
+          $ newlinePrefixed
+              [ string "where"
+              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+              ]
       _ -> return ()
 
 instance Pretty (HsMatchContext GhcPs) where
   pretty' = prettyHsMatchContext
 
 prettyHsMatchContext :: HsMatchContext GhcPs -> Printer ()
-prettyHsMatchContext FunRhs {..}       = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext LambdaExpr        = return ()
-prettyHsMatchContext CaseAlt           = return ()
-prettyHsMatchContext IfAlt {}          = notGeneratedByParser
+prettyHsMatchContext FunRhs {..} = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext LambdaExpr = return ()
+prettyHsMatchContext CaseAlt = return ()
+prettyHsMatchContext IfAlt {} = notGeneratedByParser
 prettyHsMatchContext ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext PatBindRhs {}     = notGeneratedByParser
-prettyHsMatchContext PatBindGuards {}  = notGeneratedByParser
-prettyHsMatchContext RecUpd {}         = notGeneratedByParser
-prettyHsMatchContext StmtCtxt {}       = notGeneratedByParser
-prettyHsMatchContext ThPatSplice {}    = notGeneratedByParser
-prettyHsMatchContext ThPatQuote {}     = notGeneratedByParser
-prettyHsMatchContext PatSyn {}         = notGeneratedByParser
+prettyHsMatchContext PatBindRhs {} = notGeneratedByParser
+prettyHsMatchContext PatBindGuards {} = notGeneratedByParser
+prettyHsMatchContext RecUpd {} = notGeneratedByParser
+prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
+prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
+prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
+prettyHsMatchContext PatSyn {} = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsMatchContext LamCaseAlt {}     = notUsedInParsedStage
+prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
 #endif
 instance Pretty (ParStmtBlock GhcPs GhcPs) where
   pretty' (ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
@@ -1407,8 +1421,11 @@ instance Pretty (HsSplice GhcPs) where
   pretty' (HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars $
-        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ unpackFS r
+      wrapWithBars
+        $ indentedWithFixedLevel 0
+        $ sequence_
+        $ printers [] ""
+        $ unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1472,13 +1489,13 @@ prettyPat (SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat HsRecFields {..}) =
     case fieldPrinters of
-      []  -> string "{}"
+      [] -> string "{}"
       [x] -> braces x
-      xs  -> hvFields xs
+      xs -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds ++
-        maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds
+          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsBracket GhcPs) where
   pretty' (ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
@@ -1492,10 +1509,10 @@ instance Pretty (HsBracket GhcPs) where
   pretty' (TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x)         = pretty x
-  pretty' (Bind x)        = pretty x
-  pretty' (TypeFamily x)  = pretty x
-  pretty' (TyFamInst x)   = pretty x
+  pretty' (Sig x) = pretty x
+  pretty' (Bind x) = pretty x
+  pretty' (TypeFamily x) = pretty x
+  pretty' (TyFamInst x) = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty EpaComment where
@@ -1517,7 +1534,7 @@ instance Pretty (HsValBindsLR GhcPs GhcPs) where
 
 instance Pretty (HsTupArg GhcPs) where
   pretty' (Present _ e) = pretty e
-  pretty' Missing {}    = pure () -- This appears in a tuple section.
+  pretty' Missing {} = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1615,7 +1632,7 @@ instance Pretty (ConDeclField GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (L _ (HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x)                    = pretty' x
+  pretty' (InfixExpr x) = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1675,9 +1692,9 @@ instance Pretty InfixApp where
       Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x)    = pretty x
-  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
+  pretty' (Var x) = pretty x
+  pretty' (And xs) = hvCommaSep $ fmap pretty xs
+  pretty' (Or xs) = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
 instance Pretty (FieldLabelStrings GhcPs) where
@@ -1685,7 +1702,7 @@ instance Pretty (FieldLabelStrings GhcPs) where
 
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
-  pretty' (Ambiguous _ name)   = pretty name
+  pretty' (Ambiguous _ name) = pretty name
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1702,8 +1719,9 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclImportList $ \(x, ps) -> do
       when (x == EverythingBut) (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
-        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
+        <-|> (newline
+                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #else
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1720,8 +1738,9 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclHiding $ \(x, ps) -> do
       when x (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
-        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
+        <-|> (newline
+                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #endif
 packageName :: ImportDecl GhcPs -> Maybe StringLiteral
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -1744,14 +1763,14 @@ instance Pretty (HsDerivingClause GhcPs) where
 
 instance Pretty (DerivClauseTys GhcPs) where
   pretty' (DctSingle _ ty) = parens $ pretty ty
-  pretty' (DctMulti _ ts)  = hvTuple $ fmap pretty ts
+  pretty' (DctMulti _ ts) = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
-  pretty' NoOverlap {}    = notUsedInParsedStage
+  pretty' NoOverlap {} = notUsedInParsedStage
   pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
+  pretty' Overlapping {} = string "{-# OVERLAPPING #-}"
+  pretty' Overlaps {} = string "{-# OVERLAPS #-}"
+  pretty' Incoherent {} = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
@@ -1759,13 +1778,13 @@ instance Pretty StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (FamilyDecl GhcPs) where
   pretty' FamilyDecl {..} = do
-    string $
-      case fdInfo of
-        DataFamily          -> "data"
-        OpenTypeFamily      -> "type"
-        ClosedTypeFamily {} -> "type"
+    string
+      $ case fdInfo of
+          DataFamily -> "data"
+          OpenTypeFamily -> "type"
+          ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel    -> string " family "
+      TopLevel -> string " family "
       NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> hsq_explicit fdTyVars
@@ -1788,8 +1807,8 @@ instance Pretty (FamilyDecl GhcPs) where
       _ -> pure ()
 
 instance Pretty (FamilyResultSig GhcPs) where
-  pretty' NoSig {}       = pure ()
-  pretty' (KindSig _ x)  = string ":: " >> pretty x
+  pretty' NoSig {} = pure ()
+  pretty' (KindSig _ x) = string ":: " >> pretty x
   pretty' (TyVarSig _ x) = pretty x
 
 instance Pretty (HsTyVarBndr a GhcPs) where
@@ -1808,8 +1827,8 @@ instance Pretty (ArithSeqInfo GhcPs) where
   pretty' (FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (FromThenTo from next to) =
-    brackets $
-    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets
+      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (HsForAllTelescope GhcPs) where
   pretty' HsForAllVis {..} = do
@@ -1855,9 +1874,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (L _ [])  -> parens
+          (L _ []) -> parens
           (L _ [_]) -> id
-          _         -> parens
+          _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(L _ [])) =
@@ -1872,10 +1891,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing        -> id
-          Just (L _ [])  -> parens
+          Nothing -> id
+          Just (L _ []) -> parens
           Just (L _ [_]) -> id
-          Just _         -> parens
+          Just _ -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1933,7 +1952,7 @@ instance Pretty FamEqn' where
     where
       prefix =
         case famEqnFor of
-          DataFamInstDeclForTopLevel        -> "data instance"
+          DataFamInstDeclForTopLevel -> "data instance"
           DataFamInstDeclForInsideClassInst -> "data"
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
@@ -1942,17 +1961,17 @@ instance Pretty
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x)    = pretty x
+  pretty' (HsValArg x) = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {}     = notUsedInParsedStage
+  pretty' HsArgPar {} = notUsedInParsedStage
 #else
 instance Pretty
            (HsArg
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x)    = pretty x
+  pretty' (HsValArg x) = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {}     = notUsedInParsedStage
+  pretty' HsArgPar {} = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
@@ -1977,7 +1996,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -1991,7 +2010,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2009,15 +2028,15 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName GhcPs) where
-  pretty' (IEName _ name)    = pretty name
+  pretty' (IEName _ name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name)    = string "type " >> pretty name
+  pretty' (IEType _ name) = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName RdrName) where
-  pretty' (IEName name)      = pretty name
+  pretty' (IEName name) = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name)    = string "type " >> pretty name
+  pretty' (IEType _ name) = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
@@ -2146,23 +2165,23 @@ instance Pretty ForeignImport where
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, output s]
-  pretty' (CExport _ conv)                    = pretty conv
+  pretty' (CExport _ conv) = pretty conv
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
-  pretty' (CExport _ conv)                    = pretty conv
+  pretty' (CExport _ conv) = pretty conv
 #else
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
-  pretty' (CExport conv _)                    = pretty conv
+  pretty' (CExport conv _) = pretty conv
 #endif
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
 instance Pretty Safety where
-  pretty' PlaySafe          = string "safe"
+  pretty' PlaySafe = string "safe"
   pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky         = string "unsafe"
+  pretty' PlayRisky = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2182,14 +2201,14 @@ instance Pretty (AnnDecl GhcPs) where
 #endif
 instance Pretty (RoleAnnotDecl GhcPs) where
   pretty' (RoleAnnotDecl _ name roles) =
-    spaced $
-    [string "type role", pretty name] ++
-    fmap (maybe (string "_") pretty . unLoc) roles
+    spaced
+      $ [string "type role", pretty name]
+          ++ fmap (maybe (string "_") pretty . unLoc) roles
 
 instance Pretty Role where
-  pretty' Nominal          = string "nominal"
+  pretty' Nominal = string "nominal"
   pretty' Representational = string "representational"
-  pretty' Phantom          = string "phantom"
+  pretty' Phantom = string "phantom"
 
 instance Pretty (TyFamInstDecl GhcPs) where
   pretty' TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2248,8 +2267,8 @@ instance Pretty InlinePragma where
     pretty inl_inline
     case inl_act of
       ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x  -> space >> brackets (string $ show x)
-      _                -> pure ()
+      ActiveAfter _ x -> space >> brackets (string $ show x)
+      _ -> pure ()
 
 instance Pretty InlineSpec where
   pretty' = prettyInlineSpec
@@ -2265,25 +2284,25 @@ prettyInlineSpec NoUserInlinePrag =
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (HsPatSynDir GhcPs) where
-  pretty' Unidirectional           = string "<-"
-  pretty' ImplicitBidirectional    = string "="
+  pretty' Unidirectional = string "<-"
+  pretty' ImplicitBidirectional = string "="
   pretty' ExplicitBidirectional {} = string "<-"
 
 instance Pretty (HsOverLit GhcPs) where
   pretty' OverLit {..} = pretty ol_val
 
 instance Pretty OverLitVal where
-  pretty' (HsIntegral x)   = pretty x
+  pretty' (HsIntegral x) = pretty x
   pretty' (HsFractional x) = pretty x
   pretty' (HsIsString _ x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
-  pretty' IL {..}                     = string $ show il_value
+  pretty' IL {..} = string $ show il_value
 #else
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..}                     = string $ show il_value
+  pretty' IL {..} = string $ show il_value
 #endif
 instance Pretty FractionalLit where
   pretty' = output
@@ -2302,7 +2321,7 @@ instance Pretty (HsLit GhcPs) where
   pretty' HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      HsString {}     -> prettyString
+      HsString {} -> prettyString
       HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2313,8 +2332,9 @@ instance Pretty (HsLit GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1) $
-                lined $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1)
+                $ lined
+                $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
@@ -2326,13 +2346,13 @@ instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
-  pretty' (HsNumTy _ x)  = string $ show x
-  pretty' (HsStrTy _ x)  = string $ ushow x
+  pretty' (HsNumTy _ x) = string $ show x
+  pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #else
 instance Pretty HsTyLit where
-  pretty' (HsNumTy _ x)  = string $ show x
-  pretty' (HsStrTy _ x)  = string $ ushow x
+  pretty' (HsNumTy _ x) = string $ show x
+  pretty' (HsStrTy _ x) = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (HsPatSigType GhcPs) where
@@ -2354,10 +2374,10 @@ prettyIPBind (IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (DerivStrategy GhcPs) where
-  pretty' StockStrategy {}    = string "stock"
+  pretty' StockStrategy {} = string "stock"
   pretty' AnyclassStrategy {} = string "anyclass"
-  pretty' NewtypeStrategy {}  = string "newtype"
-  pretty' (ViaStrategy x)     = string "via " >> pretty x
+  pretty' NewtypeStrategy {} = string "newtype"
+  pretty' (ViaStrategy x) = string "via " >> pretty x
 
 instance Pretty XViaStrategyPs where
   pretty' (XViaStrategyPs _ ty) = pretty ty
@@ -2425,9 +2445,12 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets $
-        spaced
-          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
+        brackets
+          $ spaced
+              [ pretty listCompLhs
+              , string "|"
+              , hCommaSep $ fmap pretty listCompRhs
+              ]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2445,7 +2468,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do  = string "do"
+  pretty' Do = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2465,10 +2488,10 @@ instance Pretty (RuleBndr GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
-  pretty' CCallConv          = string "ccall"
-  pretty' CApiConv           = string "capi"
-  pretty' StdCallConv        = string "stdcall"
-  pretty' PrimCallConv       = string "prim"
+  pretty' CCallConv = string "ccall"
+  pretty' CApiConv = string "capi"
+  pretty' StdCallConv = string "stdcall"
+  pretty' PrimCallConv = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
 #if MIN_VERSION_ghc_lib_parser(9, 8, 1)
 instance Pretty ModuleDeprecatedPragma where
@@ -2498,13 +2521,13 @@ instance Pretty HsSrcBang where
     pretty strictness
 
 instance Pretty SrcUnpackedness where
-  pretty' SrcUnpack   = string "{-# UNPACK #-}"
+  pretty' SrcUnpack = string "{-# UNPACK #-}"
   pretty' SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' NoSrcUnpack = pure ()
 
 instance Pretty SrcStrictness where
-  pretty' SrcLazy     = string "~"
-  pretty' SrcStrict   = string "!"
+  pretty' SrcLazy = string "~"
+  pretty' SrcStrict = string "!"
   pretty' NoSrcStrict = pure ()
 
 instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
@@ -2528,8 +2551,11 @@ instance Pretty (HsUntypedSplice GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars .
-         indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
+        (wrapWithBars
+           . indentedWithFixedLevel 0
+           . sequence_
+           . printers [] ""
+           . unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2484,7 +2484,8 @@ instance Pretty ModuleDeprecatedPragma where
     spaced [string "{-# WARNING", hList $ fmap pretty msgs, string "#-}"]
   pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ [msg])) =
     spaced [string "{-# DEPRECATED", pretty msg, string "#-}"]
-  pretty' _ = undefined
+  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ msgs)) =
+    spaced [string "{-# DEPRECATED", hList $ fmap pretty msgs, string "#-}"]
 #endif
 instance Pretty HsSrcBang where
   pretty' (HsSrcBang _ unpack strictness) = do

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 -- | Pretty printing.
 --
@@ -21,45 +21,45 @@ module HIndent.Pretty
   , printCommentsAnd
   ) where
 
-import Control.Monad
-import Control.Monad.RWS
-import Data.Maybe
-import Data.Void
-import GHC.Core.Coercion
-import GHC.Core.InstEnv
-import GHC.Data.Bag
-import GHC.Data.BooleanFormula
-import GHC.Data.FastString
-import GHC.Hs
-import GHC.Stack
-import GHC.Types.Basic
-import GHC.Types.Fixity
-import GHC.Types.ForeignCall
-import GHC.Types.Name
-import GHC.Types.Name.Reader
-import GHC.Types.SourceText
-import GHC.Types.SrcLoc
-import GHC.Unit.Module.Warnings
-import HIndent.Applicative
-import HIndent.Ast.NodeComments
-import HIndent.Config
-import HIndent.Fixity
-import HIndent.Pretty.Combinators
-import HIndent.Pretty.NodeComments
-import HIndent.Pretty.SigBindFamily
-import HIndent.Pretty.Types
-import HIndent.Printer
-import Language.Haskell.GhclibParserEx.GHC.Hs.Expr
-import Text.Show.Unicode
+import           Control.Monad
+import           Control.Monad.RWS
+import           Data.Maybe
+import           Data.Void
+import           GHC.Core.Coercion
+import           GHC.Core.InstEnv
+import           GHC.Data.Bag
+import           GHC.Data.BooleanFormula
+import           GHC.Data.FastString
+import           GHC.Hs
+import           GHC.Stack
+import           GHC.Types.Basic
+import           GHC.Types.Fixity
+import           GHC.Types.ForeignCall
+import           GHC.Types.Name
+import           GHC.Types.Name.Reader
+import           GHC.Types.SourceText
+import           GHC.Types.SrcLoc
+import           GHC.Unit.Module.Warnings
+import           HIndent.Applicative
+import           HIndent.Ast.NodeComments
+import           HIndent.Config
+import           HIndent.Fixity
+import           HIndent.Pretty.Combinators
+import           HIndent.Pretty.NodeComments
+import           HIndent.Pretty.SigBindFamily
+import           HIndent.Pretty.Types
+import           HIndent.Printer
+import           Language.Haskell.GhclibParserEx.GHC.Hs.Expr
+import           Text.Show.Unicode
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
-import qualified Data.Foldable as NonEmpty
-import GHC.Core.DataCon
+import qualified Data.Foldable                               as NonEmpty
+import           GHC.Core.DataCon
 #endif
 #if !MIN_VERSION_ghc_lib_parser(9,6,1)
-import GHC.Unit
+import           GHC.Unit
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-import GHC.Types.PkgQual
+import           GHC.Types.PkgQual
 #endif
 -- | This function pretty-prints the given AST node with comments.
 pretty :: Pretty a => a -> Printer ()
@@ -93,10 +93,8 @@ printCommentOnSameLine (commentsOnSameLine . nodeComments -> (c:cs)) = do
   col <- gets psColumn
   if col == 0
     then indentedWithFixedLevel
-           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c)
-           $ spaced
-           $ fmap pretty
-           $ c : cs
+           (fromIntegral $ srcSpanStartCol $ anchor $ getLoc c) $
+         spaced $ fmap pretty $ c : cs
     else spacePrefixed $ fmap pretty $ c : cs
   eolCommentsArePrinted
 printCommentOnSameLine _ = return ()
@@ -132,19 +130,19 @@ instance (CommentExtraction l, Pretty e) => Pretty (GenLocated l e) where
   pretty' (L _ e) = pretty e
 
 instance Pretty (HsDecl GhcPs) where
-  pretty' (TyClD _ d) = pretty d
-  pretty' (InstD _ inst) = pretty inst
-  pretty' (DerivD _ x) = pretty x
-  pretty' (ValD _ bind) = pretty bind
-  pretty' (SigD _ s) = pretty s
-  pretty' (KindSigD _ x) = pretty x
-  pretty' (DefD _ x) = pretty x
-  pretty' (ForD _ x) = pretty x
-  pretty' (WarningD _ x) = pretty x
-  pretty' (AnnD _ x) = pretty x
-  pretty' (RuleD _ x) = pretty x
-  pretty' (SpliceD _ sp) = pretty sp
-  pretty' DocD {} = docNode
+  pretty' (TyClD _ d)      = pretty d
+  pretty' (InstD _ inst)   = pretty inst
+  pretty' (DerivD _ x)     = pretty x
+  pretty' (ValD _ bind)    = pretty bind
+  pretty' (SigD _ s)       = pretty s
+  pretty' (KindSigD _ x)   = pretty x
+  pretty' (DefD _ x)       = pretty x
+  pretty' (ForD _ x)       = pretty x
+  pretty' (WarningD _ x)   = pretty x
+  pretty' (AnnD _ x)       = pretty x
+  pretty' (RuleD _ x)      = pretty x
+  pretty' (SpliceD _ sp)   = pretty sp
+  pretty' DocD {}          = docNode
   pretty' (RoleAnnotD _ x) = pretty x
 
 instance Pretty (TyClDecl GhcPs) where
@@ -182,7 +180,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_cons tcdDataDefn of
         DataTypeCons {} -> string "data "
-        NewTypeCon {} -> string "newtype "
+        NewTypeCon {}   -> string "newtype "
 #elif MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -197,7 +195,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType -> string "newtype "
+        NewType  -> string "newtype "
 #else
 prettyTyClDecl DataDecl {..} = do
   printDataNewtype |=> do
@@ -212,7 +210,7 @@ prettyTyClDecl DataDecl {..} = do
     printDataNewtype =
       case dd_ND tcdDataDefn of
         DataType -> string "data "
-        NewType -> string "newtype "
+        NewType  -> string "newtype "
 #endif
 prettyTyClDecl ClassDecl {..} = do
   if isJust tcdCtxt
@@ -233,21 +231,20 @@ prettyTyClDecl ClassDecl {..} = do
       string "class " |=> do
         whenJust tcdCtxt $ \ctx -> do
           printCommentsAnd ctx $ \case
-            [] -> string "()"
+            []  -> string "()"
             [x] -> pretty x
-            xs -> hvTuple $ fmap pretty xs
+            xs  -> hvTuple $ fmap pretty xs
           string " =>"
           newline
         printNameAndTypeVariables
       unless (null tcdFDs) $ do
         newline
-        indentedBlock
-          $ string "| "
-              |=> vCommaSep
-                    (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
-                       printCommentsAnd x $ \(FunDep _ from to) ->
-                         spaced
-                           $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
+        indentedBlock $
+          string "| " |=>
+          vCommaSep
+            (flip fmap tcdFDs $ \x@(L _ FunDep {}) ->
+               printCommentsAnd x $ \(FunDep _ from to) ->
+                 spaced $ fmap pretty from ++ [string "->"] ++ fmap pretty to)
       unless (null sigsMethodsFamilies) $ do
         newline
         indentedBlock $ string "where"
@@ -258,27 +255,27 @@ prettyTyClDecl ClassDecl {..} = do
         Infix ->
           case hsq_explicit tcdTyVars of
             (l:r:xs) -> do
-              parens
-                $ spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
+              parens $
+                spaced [pretty l, pretty $ fmap InfixOp tcdLName, pretty r]
               spacePrefixed $ fmap pretty xs
             _ -> error "Not enough parameters are given."
     sigsMethodsFamilies =
       mkSortedLSigBindFamilyList tcdSigs (bagToList tcdMeths) tcdATs [] []
 
 instance Pretty (InstDecl GhcPs) where
-  pretty' ClsInstD {..} = pretty cid_inst
+  pretty' ClsInstD {..}     = pretty cid_inst
   pretty' DataFamInstD {..} = pretty dfid_inst
-  pretty' TyFamInstD {..} = pretty $ TopLevelTyFamInstDecl tfid_inst
+  pretty' TyFamInstD {..}   = pretty $ TopLevelTyFamInstDecl tfid_inst
 
 instance Pretty (HsBind GhcPs) where
   pretty' = prettyHsBind
 
 prettyHsBind :: HsBind GhcPs -> Printer ()
-prettyHsBind FunBind {..} = pretty fun_matches
-prettyHsBind PatBind {..} = pretty pat_lhs >> pretty pat_rhs
-prettyHsBind VarBind {} = notGeneratedByParser
+prettyHsBind FunBind {..}     = pretty fun_matches
+prettyHsBind PatBind {..}     = pretty pat_lhs >> pretty pat_rhs
+prettyHsBind VarBind {}       = notGeneratedByParser
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsBind AbsBinds {} = notGeneratedByParser
+prettyHsBind AbsBinds {}      = notGeneratedByParser
 #endif
 prettyHsBind (PatSynBind _ x) = pretty x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
@@ -298,10 +295,9 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -321,9 +317,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
     spaced [string "{-#", pretty detail, pretty name, string "#-}"]
@@ -366,10 +362,9 @@ instance Pretty (Sig GhcPs) where
           then space |=> pretty (HsSigTypeInsideDeclSig <$> hswc_body params)
           else do
             newline
-            indentedBlock
-              $ indentedWithSpace 3
-              $ pretty
-              $ HsSigTypeInsideDeclSig <$> hswc_body params
+            indentedBlock $
+              indentedWithSpace 3 $
+              pretty $ HsSigTypeInsideDeclSig <$> hswc_body params
       printFunName = hCommaSep $ fmap pretty funName
   pretty' (PatSynSig _ names sig) =
     spaced
@@ -389,9 +384,9 @@ instance Pretty (Sig GhcPs) where
       hor = space >> printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
       ver = do
         newline
-        indentedBlock
-          $ indentedWithSpace 3
-          $ printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
+        indentedBlock $
+          indentedWithSpace 3 $
+          printCommentsAnd params (pretty . HsSigTypeInsideDeclSig)
   pretty' IdSig {} = notGeneratedByParser
   pretty' (FixSig _ x) = pretty x
   pretty' (InlineSig _ name detail) =
@@ -450,12 +445,12 @@ instance Pretty (HsDataDefn GhcPs) where
     where
       cons =
         case dd_cons of
-          NewTypeCon x -> [x]
+          NewTypeCon x      -> [x]
           DataTypeCons _ xs -> xs
       isGADT =
         case dd_cons of
           (DataTypeCons _ (L _ ConDeclGADT {}:_)) -> True
-          _ -> False
+          _                                       -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -491,7 +486,7 @@ instance Pretty (HsDataDefn GhcPs) where
       isGADT =
         case dd_cons of
           (L _ ConDeclGADT {}:_) -> True
-          _ -> False
+          _                      -> False
       derivingsAfterNewline =
         unless (null dd_derivs) $ newline >> printDerivings
       printDerivings = lined $ fmap pretty dd_derivs
@@ -502,8 +497,8 @@ instance Pretty (ClsInstDecl GhcPs) where
       whenJust cid_overlap_mode $ \x -> do
         pretty x
         space
-      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty)
-        |=> unless (null sigsAndMethods) (string " where")
+      pretty (fmap HsSigTypeInsideInstDecl cid_poly_ty) |=>
+        unless (null sigsAndMethods) (string " where")
     unless (null sigsAndMethods) $ do
       newline
       indentedBlock $ lined $ fmap pretty sigsAndMethods
@@ -549,18 +544,17 @@ prettyHsExpr (HsApp _ l r) = horizontal <-|> vertical
     vertical = do
       let (f, args) =
             case flatten l ++ [r] of
-              [] -> error "Invalid function application."
+              []         -> error "Invalid function application."
               (f':args') -> (f', args')
       col <- gets psColumn
       spaces <- getIndentSpaces
       pretty f
       col' <- gets psColumn
       let diff =
-            col'
-              - col
-              - if col == 0
-                  then spaces
-                  else 0
+            col' - col -
+            if col == 0
+              then spaces
+              else 0
       if diff + 1 <= spaces
         then space
         else newline
@@ -598,11 +592,11 @@ prettyHsExpr (ExplicitTuple _ full _) = horizontal <-|> vertical
   where
     horizontal = hTuple $ fmap pretty full
     vertical =
-      parens
-        $ prefixedLined ","
-        $ fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
+      parens $
+      prefixedLined "," $
+      fmap (\e -> unless (isMissing e) (space |=> pretty e)) full
     isMissing Missing {} = True
-    isMissing _ = False
+    isMissing _          = False
 prettyHsExpr (ExplicitSum _ position numElem expr) = do
   string "(#"
   forM_ [1 .. numElem] $ \idx -> do
@@ -627,9 +621,9 @@ prettyHsExpr (HsIf _ cond t f) = do
     branch :: String -> LHsExpr GhcPs -> Printer ()
     branch str e =
       case e of
-        (L _ (HsDo _ (DoExpr m) xs)) -> doStmt (QualifiedDo m Do) xs
+        (L _ (HsDo _ (DoExpr m) xs))  -> doStmt (QualifiedDo m Do) xs
         (L _ (HsDo _ (MDoExpr m) xs)) -> doStmt (QualifiedDo m Mdo) xs
-        _ -> string str |=> pretty e
+        _                             -> string str |=> pretty e
       where
         doStmt qDo stmts = do
           string str
@@ -637,8 +631,8 @@ prettyHsExpr (HsIf _ cond t f) = do
           newline
           indentedBlock $ printCommentsAnd stmts (lined . fmap pretty)
 prettyHsExpr (HsMultiIf _ guards) =
-  string "if "
-    |=> lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
+  string "if " |=>
+  lined (fmap (pretty . fmap (GRHSExpr GRHSExprMultiWayIf)) guards)
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyHsExpr (HsLet _ _ binds _ exprs) = pretty $ LetIn binds exprs
 #else
@@ -701,9 +695,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsFieldBind a b)]
@@ -731,9 +725,9 @@ prettyHsExpr (RecordUpd _ name fields) = hor <-|> ver
     ver = do
       pretty name
       newline
-      indentedBlock
-        $ either printHorFields printHorFields fields
-            <-|> either printVerFields printVerFields fields
+      indentedBlock $
+        either printHorFields printHorFields fields <-|>
+        either printVerFields printVerFields fields
     printHorFields ::
          (Pretty a, Pretty b, CommentExtraction l)
       => [GenLocated l (HsRecField' a b)]
@@ -760,11 +754,10 @@ prettyHsExpr (HsGetField _ e f) = do
   dot
   pretty f
 prettyHsExpr HsProjection {..} =
-  parens
-    $ forM_ proj_flds
-    $ \x -> do
-        string "."
-        pretty x
+  parens $
+  forM_ proj_flds $ \x -> do
+    string "."
+    pretty x
 prettyHsExpr (ExprWithTySig _ e sig) = do
   pretty e
   string " :: "
@@ -776,8 +769,8 @@ prettyHsExpr (HsSpliceE _ x) = pretty x
 prettyHsExpr (HsProc _ pat x@(L _ (HsCmdTop _ (L _ (HsCmdDo _ xs))))) = do
   spaced [string "proc", pretty pat, string "-> do"]
   newline
-  indentedBlock
-    $ printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
+  indentedBlock $
+    printCommentsAnd x (const (printCommentsAnd xs (lined . fmap pretty)))
 prettyHsExpr (HsProc _ pat body) = hor <-|> ver
   where
     hor = spaced [string "proc", pretty pat, string "->", pretty body]
@@ -811,7 +804,7 @@ prettyHsExpr (HsUntypedSplice _ x) = pretty x
 instance Pretty LambdaCase where
   pretty' (LambdaCase matches caseOrCases) = do
     case caseOrCases of
-      Case -> string "\\case"
+      Case  -> string "\\case"
       Cases -> string "\\cases"
     if null $ unLoc $ mg_alts matches
       then string " {}"
@@ -838,12 +831,10 @@ instance Pretty HsSigType' where
                   ver = do
                     newline
                     pretty $ VerticalContext hst_ctxt
-               in do
-                    hor <-|> ver
-                    newline
-                    prefixed "=> "
-                      $ prefixedLined "-> "
-                      $ pretty <$> flatten hst_body
+               in do hor <-|> ver
+                     newline
+                     prefixed "=> " $
+                       prefixedLined "-> " $ pretty <$> flatten hst_body
           _ ->
             let hor = space >> pretty (fmap HsTypeInsideDeclSig sig_body)
                 ver =
@@ -853,7 +844,7 @@ instance Pretty HsSigType' where
     where
       flatten :: LHsType GhcPs -> [LHsType GhcPs]
       flatten (L _ (HsFunTy _ _ l r)) = flatten l ++ flatten r
-      flatten x = [x]
+      flatten x                       = [x]
   pretty' (HsSigTypeInsideVerticalFuncSig HsSig {..}) =
     case sig_bndrs of
       HsOuterExplicit _ xs -> do
@@ -862,8 +853,8 @@ instance Pretty HsSigType' where
         dot
         printCommentsAnd sig_body $ \case
           HsQualTy {..} -> do
-            (space >> pretty (HorizontalContext hst_ctxt))
-              <-|> (newline >> pretty (VerticalContext hst_ctxt))
+            (space >> pretty (HorizontalContext hst_ctxt)) <-|>
+              (newline >> pretty (VerticalContext hst_ctxt))
             newline
             prefixed "=> " $ pretty hst_body
           x -> pretty $ HsTypeInsideDeclSig x
@@ -893,10 +884,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -907,19 +898,19 @@ prettyConDecl ConDeclGADT {..} = do
       newline
       prefixed "=> " verArgs
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
     forallNeeded =
@@ -937,10 +928,10 @@ prettyConDecl ConDeclGADT {..} = do
       indentedBlock (string ":: " |=> body)
     body =
       case (forallNeeded, con_mb_cxt) of
-        (True, Just ctx) -> withForallCtx ctx
-        (True, Nothing) -> withForallOnly
+        (True, Just ctx)  -> withForallCtx ctx
+        (True, Nothing)   -> withForallOnly
         (False, Just ctx) -> withCtxOnly ctx
-        (False, Nothing) -> noForallCtx
+        (False, Nothing)  -> noForallCtx
     withForallOnly = do
       pretty con_bndrs
       (space >> horArgs) <-|> (newline >> verArgs)
@@ -951,52 +942,52 @@ prettyConDecl ConDeclGADT {..} = do
       (space >> pretty (Context ctx)) <-|> (newline >> pretty (Context ctx))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly ctx =
-      (pretty (Context ctx) >> string " => " >> horArgs)
-        <-|> (pretty (Context ctx) >> prefixed "=> " verArgs)
-    
+      (pretty (Context ctx) >> string " => " >> horArgs) <-|>
+      (pretty (Context ctx) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs _ -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #else
     withForallCtx _ = do
       pretty con_bndrs
-      (space >> pretty (Context con_mb_cxt))
-        <-|> (newline >> pretty (Context con_mb_cxt))
+      (space >> pretty (Context con_mb_cxt)) <-|>
+        (newline >> pretty (Context con_mb_cxt))
       newline
       prefixed "=> " verArgs
-    
+
     withCtxOnly _ =
-      (pretty (Context con_mb_cxt) >> string " => " >> horArgs)
-        <-|> (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
-    
+      (pretty (Context con_mb_cxt) >> string " => " >> horArgs) <-|>
+      (pretty (Context con_mb_cxt) >> prefixed "=> " verArgs)
+
     horArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          inter (string " -> ")
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          inter (string " -> ") $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> inter (string " -> ") [recArg xs, pretty con_res_ty]
-    
+
     verArgs =
       case con_g_args of
         PrefixConGADT xs ->
-          prefixedLined "-> "
-            $ fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
+          prefixedLined "-> " $
+          fmap (\(HsScaled _ x) -> pretty x) xs ++ [pretty con_res_ty]
         RecConGADT xs -> prefixedLined "-> " [recArg xs, pretty con_res_ty]
 #endif
     recArg xs = printCommentsAnd xs $ \xs' -> vFields' $ fmap pretty xs'
-    
+
     forallNeeded =
       case unLoc con_bndrs of
         HsOuterImplicit {} -> False
@@ -1004,30 +995,26 @@ prettyConDecl ConDeclGADT {..} = do
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \c -> do
-             pretty $ Context c
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \c -> do
+        pretty $ Context c
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #else
 prettyConDecl ConDeclH98 {con_forall = True, ..} =
-  (do
-     string "forall "
-     spaced $ fmap pretty con_ex_tvs
-     string ". ")
-    |=> (do
-           whenJust con_mb_cxt $ \_ -> do
-             pretty $ Context con_mb_cxt
-             string " =>"
-             newline
-           pretty con_name
-           pretty con_args)
+  (do string "forall "
+      spaced $ fmap pretty con_ex_tvs
+      string ". ") |=>
+  (do whenJust con_mb_cxt $ \_ -> do
+        pretty $ Context con_mb_cxt
+        string " =>"
+        newline
+      pretty con_name
+      pretty con_args)
 #endif
 prettyConDecl ConDeclH98 {con_forall = False, ..} =
   case con_args of
@@ -1043,11 +1030,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) where
 prettyMatchExpr :: Match GhcPs (LHsExpr GhcPs) -> Printer ()
 prettyMatchExpr Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case unLoc $ head m_pats of
-        LazyPat {} -> space
-        BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case unLoc $ head m_pats of
+      LazyPat {} -> space
+      BangPat {} -> space
+      _          -> return ()
   spaced $ fmap pretty m_pats
   pretty $ GRHSsExpr GRHSExprLambda m_grhss
 prettyMatchExpr Match {m_ctxt = CaseAlt, ..} = do
@@ -1067,9 +1054,8 @@ prettyMatchExpr Match {..} =
     Infix -> do
       case (m_pats, m_ctxt) of
         (l:r:xs, FunRhs {..}) -> do
-          spaced
-            $ [pretty l, pretty $ fmap InfixOp mc_fun, pretty r]
-                ++ fmap pretty xs
+          spaced $
+            [pretty l, pretty $ fmap InfixOp mc_fun, pretty r] ++ fmap pretty xs
           pretty m_grhss
         _ -> error "Not enough parameters are passed."
 
@@ -1079,11 +1065,11 @@ instance Pretty (Match GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
 prettyMatchProc :: Match GhcPs (LHsCmd GhcPs) -> Printer ()
 prettyMatchProc Match {m_ctxt = LambdaExpr, ..} = do
   string "\\"
-  unless (null m_pats)
-    $ case unLoc $ head m_pats of
-        LazyPat {} -> space
-        BangPat {} -> space
-        _ -> return ()
+  unless (null m_pats) $
+    case unLoc $ head m_pats of
+      LazyPat {} -> space
+      BangPat {} -> space
+      _          -> return ()
   spaced $ fmap pretty m_pats ++ [pretty m_grhss]
 prettyMatchProc Match {m_ctxt = CaseAlt, ..} =
   spaced [mapM_ pretty m_pats, pretty m_grhss]
@@ -1143,7 +1129,7 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (Pat GhcPs))) where
     where
       horizontal =
         case rec_dotdot of
-          Just _ -> braces $ string ".."
+          Just _  -> braces $ string ".."
           Nothing -> hFields $ fmap pretty rec_flds
       vertical = vFields $ fmap pretty rec_flds
 
@@ -1152,8 +1138,8 @@ instance Pretty (HsRecFields GhcPs (GenLocated SrcSpanAnnA (HsExpr GhcPs))) wher
   pretty' HsRecFields {..} = hvFields fieldPrinters
     where
       fieldPrinters =
-        fmap pretty rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap pretty rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 
 instance Pretty (HsType GhcPs) where
   pretty' = pretty' . HsType' HsTypeForNormalDecl HsTypeNoDir
@@ -1258,7 +1244,7 @@ prettyHsType (HsRecTy _ xs) = hvFields $ fmap pretty xs
 prettyHsType (HsExplicitListTy _ _ xs) =
   case xs of
     [] -> string "'[]"
-    _ -> hvPromotedList $ fmap pretty xs
+    _  -> hvPromotedList $ fmap pretty xs
 prettyHsType (HsExplicitTupleTy _ xs) = hPromotedTuple $ fmap pretty xs
 prettyHsType (HsTyLit _ x) = pretty x
 prettyHsType HsWildCardTy {} = string "_"
@@ -1276,11 +1262,11 @@ instance Pretty GRHSsExpr where
           newline
           string "where " |=> pretty grhssLocalBinds
       (HsValBinds epa lr, _) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
@@ -1288,31 +1274,31 @@ instance Pretty (GRHSs GhcPs (GenLocated SrcSpanAnnA (HsCmd GhcPs))) where
     mapM_ (pretty . fmap GRHSProc) grhssGRHSs
     case grhssLocalBinds of
       (HsValBinds epa lr) ->
-        indentedWithSpace 2
-          $ newlinePrefixed
-              [ string "where"
-              , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
-              ]
+        indentedWithSpace 2 $
+        newlinePrefixed
+          [ string "where"
+          , printCommentsAnd (L epa lr) (indentedWithSpace 2 . pretty)
+          ]
       _ -> return ()
 
 instance Pretty (HsMatchContext GhcPs) where
   pretty' = prettyHsMatchContext
 
 prettyHsMatchContext :: HsMatchContext GhcPs -> Printer ()
-prettyHsMatchContext FunRhs {..} = pretty mc_strictness >> pretty mc_fun
-prettyHsMatchContext LambdaExpr = return ()
-prettyHsMatchContext CaseAlt = return ()
-prettyHsMatchContext IfAlt {} = notGeneratedByParser
+prettyHsMatchContext FunRhs {..}       = pretty mc_strictness >> pretty mc_fun
+prettyHsMatchContext LambdaExpr        = return ()
+prettyHsMatchContext CaseAlt           = return ()
+prettyHsMatchContext IfAlt {}          = notGeneratedByParser
 prettyHsMatchContext ArrowMatchCtxt {} = notGeneratedByParser
-prettyHsMatchContext PatBindRhs {} = notGeneratedByParser
-prettyHsMatchContext PatBindGuards {} = notGeneratedByParser
-prettyHsMatchContext RecUpd {} = notGeneratedByParser
-prettyHsMatchContext StmtCtxt {} = notGeneratedByParser
-prettyHsMatchContext ThPatSplice {} = notGeneratedByParser
-prettyHsMatchContext ThPatQuote {} = notGeneratedByParser
-prettyHsMatchContext PatSyn {} = notGeneratedByParser
+prettyHsMatchContext PatBindRhs {}     = notGeneratedByParser
+prettyHsMatchContext PatBindGuards {}  = notGeneratedByParser
+prettyHsMatchContext RecUpd {}         = notGeneratedByParser
+prettyHsMatchContext StmtCtxt {}       = notGeneratedByParser
+prettyHsMatchContext ThPatSplice {}    = notGeneratedByParser
+prettyHsMatchContext ThPatQuote {}     = notGeneratedByParser
+prettyHsMatchContext PatSyn {}         = notGeneratedByParser
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
-prettyHsMatchContext LamCaseAlt {} = notUsedInParsedStage
+prettyHsMatchContext LamCaseAlt {}     = notUsedInParsedStage
 #endif
 instance Pretty (ParStmtBlock GhcPs GhcPs) where
   pretty' (ParStmtBlock _ xs _ _) = hvCommaSep $ fmap pretty xs
@@ -1421,11 +1407,8 @@ instance Pretty (HsSplice GhcPs) where
   pretty' (HsQuasiQuote _ _ l _ r) =
     brackets $ do
       pretty l
-      wrapWithBars
-        $ indentedWithFixedLevel 0
-        $ sequence_
-        $ printers [] ""
-        $ unpackFS r
+      wrapWithBars $
+        indentedWithFixedLevel 0 $ sequence_ $ printers [] "" $ unpackFS r
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =
@@ -1489,13 +1472,13 @@ prettyPat (SigPat _ l r) = spaced [pretty l, string "::", pretty r]
 instance Pretty RecConPat where
   pretty' (RecConPat HsRecFields {..}) =
     case fieldPrinters of
-      [] -> string "{}"
+      []  -> string "{}"
       [x] -> braces x
-      xs -> hvFields xs
+      xs  -> hvFields xs
     where
       fieldPrinters =
-        fmap (pretty . fmap RecConField) rec_flds
-          ++ maybeToList (fmap (const (string "..")) rec_dotdot)
+        fmap (pretty . fmap RecConField) rec_flds ++
+        maybeToList (fmap (const (string "..")) rec_dotdot)
 #if !MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsBracket GhcPs) where
   pretty' (ExpBr _ expr) = brackets $ wrapWithBars $ pretty expr
@@ -1509,10 +1492,10 @@ instance Pretty (HsBracket GhcPs) where
   pretty' (TExpBr _ x) = typedBrackets $ pretty x
 #endif
 instance Pretty SigBindFamily where
-  pretty' (Sig x) = pretty x
-  pretty' (Bind x) = pretty x
-  pretty' (TypeFamily x) = pretty x
-  pretty' (TyFamInst x) = pretty x
+  pretty' (Sig x)         = pretty x
+  pretty' (Bind x)        = pretty x
+  pretty' (TypeFamily x)  = pretty x
+  pretty' (TyFamInst x)   = pretty x
   pretty' (DataFamInst x) = pretty $ DataFamInstDeclInsideClassInst x
 
 instance Pretty EpaComment where
@@ -1534,7 +1517,7 @@ instance Pretty (HsValBindsLR GhcPs GhcPs) where
 
 instance Pretty (HsTupArg GhcPs) where
   pretty' (Present _ e) = pretty e
-  pretty' Missing {} = pure () -- This appears in a tuple section.
+  pretty' Missing {}    = pure () -- This appears in a tuple section.
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty RecConField where
   pretty' (RecConField HsFieldBind {..}) = do
@@ -1632,7 +1615,7 @@ instance Pretty (ConDeclField GhcPs) where
 
 instance Pretty InfixExpr where
   pretty' (InfixExpr (L _ (HsVar _ bind))) = pretty $ fmap InfixOp bind
-  pretty' (InfixExpr x) = pretty' x
+  pretty' (InfixExpr x)                    = pretty' x
 
 instance Pretty InfixApp where
   pretty' InfixApp {..} = horizontal <-|> vertical
@@ -1692,9 +1675,9 @@ instance Pretty InfixApp where
       Fixity _ level dir = findFixity op
 
 instance Pretty a => Pretty (BooleanFormula a) where
-  pretty' (Var x) = pretty x
-  pretty' (And xs) = hvCommaSep $ fmap pretty xs
-  pretty' (Or xs) = hvBarSep $ fmap pretty xs
+  pretty' (Var x)    = pretty x
+  pretty' (And xs)   = hvCommaSep $ fmap pretty xs
+  pretty' (Or xs)    = hvBarSep $ fmap pretty xs
   pretty' (Parens x) = parens $ pretty x
 
 instance Pretty (FieldLabelStrings GhcPs) where
@@ -1702,7 +1685,7 @@ instance Pretty (FieldLabelStrings GhcPs) where
 
 instance Pretty (AmbiguousFieldOcc GhcPs) where
   pretty' (Unambiguous _ name) = pretty name
-  pretty' (Ambiguous _ name) = pretty name
+  pretty' (Ambiguous _ name)   = pretty name
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1719,9 +1702,8 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclImportList $ \(x, ps) -> do
       when (x == EverythingBut) (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
-        <-|> (newline
-                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
+        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #else
 instance Pretty (ImportDecl GhcPs) where
   pretty' decl@ImportDecl {..} = do
@@ -1738,9 +1720,8 @@ instance Pretty (ImportDecl GhcPs) where
       pretty x
     whenJust ideclHiding $ \(x, ps) -> do
       when x (string " hiding")
-      (string " " >> printCommentsAnd ps (hTuple . fmap pretty))
-        <-|> (newline
-                >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
+      (string " " >> printCommentsAnd ps (hTuple . fmap pretty)) <-|>
+        (newline >> indentedBlock (printCommentsAnd ps (vTuple . fmap pretty)))
 #endif
 packageName :: ImportDecl GhcPs -> Maybe StringLiteral
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
@@ -1763,14 +1744,14 @@ instance Pretty (HsDerivingClause GhcPs) where
 
 instance Pretty (DerivClauseTys GhcPs) where
   pretty' (DctSingle _ ty) = parens $ pretty ty
-  pretty' (DctMulti _ ts) = hvTuple $ fmap pretty ts
+  pretty' (DctMulti _ ts)  = hvTuple $ fmap pretty ts
 
 instance Pretty OverlapMode where
-  pretty' NoOverlap {} = notUsedInParsedStage
+  pretty' NoOverlap {}    = notUsedInParsedStage
   pretty' Overlappable {} = string "{-# OVERLAPPABLE #-}"
-  pretty' Overlapping {} = string "{-# OVERLAPPING #-}"
-  pretty' Overlaps {} = string "{-# OVERLAPS #-}"
-  pretty' Incoherent {} = string "{-# INCOHERENT #-}"
+  pretty' Overlapping {}  = string "{-# OVERLAPPING #-}"
+  pretty' Overlaps {}     = string "{-# OVERLAPS #-}"
+  pretty' Incoherent {}   = string "{-# INCOHERENT #-}"
 
 instance Pretty StringLiteral where
   pretty' = output
@@ -1778,13 +1759,13 @@ instance Pretty StringLiteral where
 -- | This instance is for type family declarations inside a class declaration.
 instance Pretty (FamilyDecl GhcPs) where
   pretty' FamilyDecl {..} = do
-    string
-      $ case fdInfo of
-          DataFamily -> "data"
-          OpenTypeFamily -> "type"
-          ClosedTypeFamily {} -> "type"
+    string $
+      case fdInfo of
+        DataFamily          -> "data"
+        OpenTypeFamily      -> "type"
+        ClosedTypeFamily {} -> "type"
     case fdTopLevel of
-      TopLevel -> string " family "
+      TopLevel    -> string " family "
       NotTopLevel -> space
     pretty fdLName
     spacePrefixed $ pretty <$> hsq_explicit fdTyVars
@@ -1807,8 +1788,8 @@ instance Pretty (FamilyDecl GhcPs) where
       _ -> pure ()
 
 instance Pretty (FamilyResultSig GhcPs) where
-  pretty' NoSig {} = pure ()
-  pretty' (KindSig _ x) = string ":: " >> pretty x
+  pretty' NoSig {}       = pure ()
+  pretty' (KindSig _ x)  = string ":: " >> pretty x
   pretty' (TyVarSig _ x) = pretty x
 
 instance Pretty (HsTyVarBndr a GhcPs) where
@@ -1827,8 +1808,8 @@ instance Pretty (ArithSeqInfo GhcPs) where
   pretty' (FromTo from to) =
     brackets $ spaced [pretty from, string "..", pretty to]
   pretty' (FromThenTo from next to) =
-    brackets
-      $ spaced [pretty from >> comma >> pretty next, string "..", pretty to]
+    brackets $
+    spaced [pretty from >> comma >> pretty next, string "..", pretty to]
 
 instance Pretty (HsForAllTelescope GhcPs) where
   pretty' HsForAllVis {..} = do
@@ -1874,9 +1855,9 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          (L _ []) -> parens
+          (L _ [])  -> parens
           (L _ [_]) -> id
-          _ -> parens
+          _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext full@(L _ [])) =
@@ -1891,10 +1872,10 @@ instance Pretty HorizontalContext where
     where
       constraintsParens =
         case xs of
-          Nothing -> id
-          Just (L _ []) -> parens
+          Nothing        -> id
+          Just (L _ [])  -> parens
           Just (L _ [_]) -> id
-          Just _ -> parens
+          Just _         -> parens
 
 instance Pretty VerticalContext where
   pretty' (VerticalContext Nothing) = pure ()
@@ -1952,7 +1933,7 @@ instance Pretty FamEqn' where
     where
       prefix =
         case famEqnFor of
-          DataFamInstDeclForTopLevel -> "data instance"
+          DataFamInstDeclForTopLevel        -> "data instance"
           DataFamInstDeclForInsideClassInst -> "data"
 -- | HsArg (LHsType GhcPs) (LHsType GhcPs)
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
@@ -1961,17 +1942,17 @@ instance Pretty
               GhcPs
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x) = pretty x
+  pretty' (HsValArg x)    = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {} = notUsedInParsedStage
+  pretty' HsArgPar {}     = notUsedInParsedStage
 #else
 instance Pretty
            (HsArg
               (GenLocated SrcSpanAnnA (HsType GhcPs))
               (GenLocated SrcSpanAnnA (HsType GhcPs))) where
-  pretty' (HsValArg x) = pretty x
+  pretty' (HsValArg x)    = pretty x
   pretty' (HsTypeArg _ x) = string "@" >> pretty x
-  pretty' HsArgPar {} = notUsedInParsedStage
+  pretty' HsArgPar {}     = notUsedInParsedStage
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,4,1)
 instance Pretty (HsQuote GhcPs) where
@@ -1996,7 +1977,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ _ reasons  -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2010,7 +1991,7 @@ instance Pretty (WarnDecl GhcPs) where
   pretty' (Warning _ names deprecatedOrWarning) =
     case deprecatedOrWarning of
       DeprecatedTxt _ reasons -> prettyWithTitleReasons "DEPRECATED" reasons
-      WarningTxt _ reasons -> prettyWithTitleReasons "WARNING" reasons
+      WarningTxt _ reasons    -> prettyWithTitleReasons "WARNING" reasons
     where
       prettyWithTitleReasons title reasons =
         lined
@@ -2028,15 +2009,15 @@ instance Pretty (WithHsDocIdentifiers StringLiteral GhcPs) where
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName GhcPs) where
-  pretty' (IEName _ name) = pretty name
+  pretty' (IEName _ name)    = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name) = string "type " >> pretty name
+  pretty' (IEType _ name)    = string "type " >> pretty name
 #else
 -- | 'Pretty' for 'LIEWrappedName (IdP GhcPs)'
 instance Pretty (IEWrappedName RdrName) where
-  pretty' (IEName name) = pretty name
+  pretty' (IEName name)      = pretty name
   pretty' (IEPattern _ name) = spaced [string "pattern", pretty name]
-  pretty' (IEType _ name) = string "type " >> pretty name
+  pretty' (IEType _ name)    = string "type " >> pretty name
 #endif
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (DotFieldOcc GhcPs) where
@@ -2165,23 +2146,23 @@ instance Pretty ForeignImport where
 #if MIN_VERSION_ghc_lib_parser(9,8,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, output s]
-  pretty' (CExport _ conv) = pretty conv
+  pretty' (CExport _ conv)                    = pretty conv
 #elif MIN_VERSION_ghc_lib_parser(9,6,0)
 instance Pretty (ForeignExport GhcPs) where
   pretty' (CExport (L _ (SourceText s)) conv) = spaced [pretty conv, string s]
-  pretty' (CExport _ conv) = pretty conv
+  pretty' (CExport _ conv)                    = pretty conv
 #else
 instance Pretty ForeignExport where
   pretty' (CExport conv (L _ (SourceText s))) = spaced [pretty conv, string s]
-  pretty' (CExport conv _) = pretty conv
+  pretty' (CExport conv _)                    = pretty conv
 #endif
 instance Pretty CExportSpec where
   pretty' (CExportStatic _ _ x) = pretty x
 
 instance Pretty Safety where
-  pretty' PlaySafe = string "safe"
+  pretty' PlaySafe          = string "safe"
   pretty' PlayInterruptible = string "interruptible"
-  pretty' PlayRisky = string "unsafe"
+  pretty' PlayRisky         = string "unsafe"
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (AnnDecl GhcPs) where
   pretty' (HsAnnotation _ (ValueAnnProvenance name) expr) =
@@ -2201,14 +2182,14 @@ instance Pretty (AnnDecl GhcPs) where
 #endif
 instance Pretty (RoleAnnotDecl GhcPs) where
   pretty' (RoleAnnotDecl _ name roles) =
-    spaced
-      $ [string "type role", pretty name]
-          ++ fmap (maybe (string "_") pretty . unLoc) roles
+    spaced $
+    [string "type role", pretty name] ++
+    fmap (maybe (string "_") pretty . unLoc) roles
 
 instance Pretty Role where
-  pretty' Nominal = string "nominal"
+  pretty' Nominal          = string "nominal"
   pretty' Representational = string "representational"
-  pretty' Phantom = string "phantom"
+  pretty' Phantom          = string "phantom"
 
 instance Pretty (TyFamInstDecl GhcPs) where
   pretty' TyFamInstDecl {..} = string "type " >> pretty tfid_eqn
@@ -2267,8 +2248,8 @@ instance Pretty InlinePragma where
     pretty inl_inline
     case inl_act of
       ActiveBefore _ x -> space >> brackets (string $ "~" ++ show x)
-      ActiveAfter _ x -> space >> brackets (string $ show x)
-      _ -> pure ()
+      ActiveAfter _ x  -> space >> brackets (string $ show x)
+      _                -> pure ()
 
 instance Pretty InlineSpec where
   pretty' = prettyInlineSpec
@@ -2284,25 +2265,25 @@ prettyInlineSpec NoUserInlinePrag =
 prettyInlineSpec Opaque {} = string "OPAQUE"
 #endif
 instance Pretty (HsPatSynDir GhcPs) where
-  pretty' Unidirectional = string "<-"
-  pretty' ImplicitBidirectional = string "="
+  pretty' Unidirectional           = string "<-"
+  pretty' ImplicitBidirectional    = string "="
   pretty' ExplicitBidirectional {} = string "<-"
 
 instance Pretty (HsOverLit GhcPs) where
   pretty' OverLit {..} = pretty ol_val
 
 instance Pretty OverLitVal where
-  pretty' (HsIntegral x) = pretty x
+  pretty' (HsIntegral x)   = pretty x
   pretty' (HsFractional x) = pretty x
   pretty' (HsIsString _ x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = output s
-  pretty' IL {..} = string $ show il_value
+  pretty' IL {..}                     = string $ show il_value
 #else
 instance Pretty IntegralLit where
   pretty' IL {il_text = SourceText s} = string s
-  pretty' IL {..} = string $ show il_value
+  pretty' IL {..}                     = string $ show il_value
 #endif
 instance Pretty FractionalLit where
   pretty' = output
@@ -2321,7 +2302,7 @@ instance Pretty (HsLit GhcPs) where
   pretty' HsDoublePrim {} = notUsedInParsedStage
   pretty' x =
     case x of
-      HsString {} -> prettyString
+      HsString {}     -> prettyString
       HsStringPrim {} -> prettyString
     where
       prettyString =
@@ -2332,9 +2313,8 @@ instance Pretty (HsLit GhcPs) where
             string "" |=> do
               string s
               newline
-              indentedWithSpace (-1)
-                $ lined
-                $ fmap (string . dropWhile (/= '\\')) ss
+              indentedWithSpace (-1) $
+                lined $ fmap (string . dropWhile (/= '\\')) ss
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsPragE GhcPs) where
   pretty' (HsPragSCC _ x) = spaced [string "{-# SCC", pretty x, string "#-}"]
@@ -2346,13 +2326,13 @@ instance Pretty HsIPName where
   pretty' (HsIPName x) = string $ unpackFS x
 #if MIN_VERSION_ghc_lib_parser(9,6,1)
 instance Pretty (HsTyLit GhcPs) where
-  pretty' (HsNumTy _ x) = string $ show x
-  pretty' (HsStrTy _ x) = string $ ushow x
+  pretty' (HsNumTy _ x)  = string $ show x
+  pretty' (HsStrTy _ x)  = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #else
 instance Pretty HsTyLit where
-  pretty' (HsNumTy _ x) = string $ show x
-  pretty' (HsStrTy _ x) = string $ ushow x
+  pretty' (HsNumTy _ x)  = string $ show x
+  pretty' (HsStrTy _ x)  = string $ ushow x
   pretty' (HsCharTy _ x) = string $ show x
 #endif
 instance Pretty (HsPatSigType GhcPs) where
@@ -2374,10 +2354,10 @@ prettyIPBind (IPBind _ (Left l) r) =
   spaced [string "?" >> pretty l, string "=", pretty r]
 #endif
 instance Pretty (DerivStrategy GhcPs) where
-  pretty' StockStrategy {} = string "stock"
+  pretty' StockStrategy {}    = string "stock"
   pretty' AnyclassStrategy {} = string "anyclass"
-  pretty' NewtypeStrategy {} = string "newtype"
-  pretty' (ViaStrategy x) = string "via " >> pretty x
+  pretty' NewtypeStrategy {}  = string "newtype"
+  pretty' (ViaStrategy x)     = string "via " >> pretty x
 
 instance Pretty XViaStrategyPs where
   pretty' (XViaStrategyPs _ ty) = pretty ty
@@ -2445,12 +2425,9 @@ instance Pretty ListComprehension where
   pretty' ListComprehension {..} = horizontal <-|> vertical
     where
       horizontal =
-        brackets
-          $ spaced
-              [ pretty listCompLhs
-              , string "|"
-              , hCommaSep $ fmap pretty listCompRhs
-              ]
+        brackets $
+        spaced
+          [pretty listCompLhs, string "|", hCommaSep $ fmap pretty listCompRhs]
       vertical = do
         string "[ "
         pretty $ fmap StmtLRInsideVerticalList listCompLhs
@@ -2468,7 +2445,7 @@ instance Pretty DoExpression where
     indentedBlock $ lined $ fmap pretty doStmts
 
 instance Pretty DoOrMdo where
-  pretty' Do = string "do"
+  pretty' Do  = string "do"
   pretty' Mdo = string "mdo"
 
 instance Pretty QualifiedDo where
@@ -2488,10 +2465,10 @@ instance Pretty (RuleBndr GhcPs) where
     parens $ spaced [pretty name, string "::", pretty sig]
 
 instance Pretty CCallConv where
-  pretty' CCallConv = string "ccall"
-  pretty' CApiConv = string "capi"
-  pretty' StdCallConv = string "stdcall"
-  pretty' PrimCallConv = string "prim"
+  pretty' CCallConv          = string "ccall"
+  pretty' CApiConv           = string "capi"
+  pretty' StdCallConv        = string "stdcall"
+  pretty' PrimCallConv       = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
 #if MIN_VERSION_ghc_lib_parser(9,8,1)
 instance Pretty ModuleDeprecatedPragma where
@@ -2501,10 +2478,13 @@ instance Pretty ModuleDeprecatedPragma where
     spaced [string "{-# DEPRECATED", spaced $ fmap pretty xs, string "#-}"]
 #else
 instance Pretty ModuleDeprecatedPragma where
-  pretty' (ModuleDeprecatedPragma (WarningTxt _ xs)) =
-    spaced [string "{-# WARNING", spaced $ fmap pretty xs, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ xs)) =
-    spaced [string "{-# DEPRECATED", spaced $ fmap pretty xs, string "#-}"]
+  pretty' (ModuleDeprecatedPragma (WarningTxt _ [msg])) =
+    spaced [string "{-# WARNING", pretty msg, string "#-}"]
+  pretty' (ModuleDeprecatedPragma (WarningTxt _ msgs)) =
+    spaced [string "{-# WARNING", hList $ fmap pretty msgs, string "#-}"]
+  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ [msg])) =
+    spaced [string "{-# DEPRECATED", pretty msg, string "#-}"]
+  pretty' _ = undefined
 #endif
 instance Pretty HsSrcBang where
   pretty' (HsSrcBang _ unpack strictness) = do
@@ -2513,13 +2493,13 @@ instance Pretty HsSrcBang where
     pretty strictness
 
 instance Pretty SrcUnpackedness where
-  pretty' SrcUnpack = string "{-# UNPACK #-}"
+  pretty' SrcUnpack   = string "{-# UNPACK #-}"
   pretty' SrcNoUnpack = string "{-# NOUNPACK #-}"
   pretty' NoSrcUnpack = pure ()
 
 instance Pretty SrcStrictness where
-  pretty' SrcLazy = string "~"
-  pretty' SrcStrict = string "!"
+  pretty' SrcLazy     = string "~"
+  pretty' SrcStrict   = string "!"
   pretty' NoSrcStrict = pure ()
 
 instance Pretty (HsOuterSigTyVarBndrs GhcPs) where
@@ -2543,11 +2523,8 @@ instance Pretty (HsUntypedSplice GhcPs) where
       pretty l
       printCommentsAnd
         r
-        (wrapWithBars
-           . indentedWithFixedLevel 0
-           . sequence_
-           . printers [] ""
-           . unpackFS)
+        (wrapWithBars .
+         indentedWithFixedLevel 0 . sequence_ . printers [] "" . unpackFS)
     where
       printers ps s [] = reverse (string (reverse s) : ps)
       printers ps s ('\n':xs) =

--- a/src/HIndent/Pretty.hs
+++ b/src/HIndent/Pretty.hs
@@ -2470,12 +2470,16 @@ instance Pretty CCallConv where
   pretty' StdCallConv        = string "stdcall"
   pretty' PrimCallConv       = string "prim"
   pretty' JavaScriptCallConv = string "javascript"
-#if MIN_VERSION_ghc_lib_parser(9,8,1)
+#if MIN_VERSION_ghc_lib_parser(9, 8, 1)
 instance Pretty ModuleDeprecatedPragma where
-  pretty' (ModuleDeprecatedPragma (WarningTxt _ _ xs)) =
-    spaced [string "{-# WARNING", spaced $ fmap pretty xs, string "#-}"]
-  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ xs)) =
-    spaced [string "{-# DEPRECATED", spaced $ fmap pretty xs, string "#-}"]
+  pretty' (ModuleDeprecatedPragma (WarningTxt _ _ [msg])) =
+    spaced [string "{-# WARNING", pretty msg, string "#-}"]
+  pretty' (ModuleDeprecatedPragma (WarningTxt _ _ msgs)) =
+    spaced [string "{-# WARNING", hList $ fmap pretty msgs, string "#-}"]
+  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ [msg])) =
+    spaced [string "{-# DEPRECATED", pretty msg, string "#-}"]
+  pretty' (ModuleDeprecatedPragma (DeprecatedTxt _ msgs)) =
+    spaced [string "{-# DEPRECATED", hList $ fmap pretty msgs, string "#-}"]
 #else
 instance Pretty ModuleDeprecatedPragma where
   pretty' (ModuleDeprecatedPragma (WarningTxt _ [msg])) =


### PR DESCRIPTION
### Description of the PR

Fixes pretty-printing module-level warnings

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
