### PR TITLE
Fix CI: make cabal file use new hpack

### DIFF
--- a/.github/workflows/presubmit-cabal.yaml
+++ b/.github/workflows/presubmit-cabal.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Haskell Compiler (cabal)
         id: setup-haskell
-        uses: haskell-actions/setup@ec49483bfc012387b227434aba94f59a6ecd0900 # v2.7.5
+        uses: haskell-actions/setup@dd344bc1cec854a369df8814ce17ef337d6e6170 # v2.7.6
         with:
           ghc-version: ${{ matrix.ghc }}
 

--- a/.github/workflows/presubmit-stack.yaml
+++ b/.github/workflows/presubmit-stack.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Setup Haskell Compiler (stack)
         id: setup-haskell
-        uses: haskell-actions/setup@ec49483bfc012387b227434aba94f59a6ecd0900 # v2.7.5
+        uses: haskell-actions/setup@dd344bc1cec854a369df8814ce17ef337d6e6170 # v2.7.6
         with:
           enable-stack: true
           stack-no-global: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Haskell Compiler (cabal)
         id: setup-haskell
-        uses: haskell-actions/setup@ec49483bfc012387b227434aba94f59a6ecd0900 # v2.7.5
+        uses: haskell-actions/setup@dd344bc1cec854a369df8814ce17ef337d6e6170 # v2.7.6
         with:
           ghc-version: ${{ env.ghc }}
 

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
### Description of the PR

We have updated `hpack` to 0.37.0, but we also need to update Cabal file.

### Checklist

- [ ] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [ ] Add tests in [TESTS.md](/TESTS.md) if possible.
