### PR TITLE
Restrict to `Cabal < 3.12`

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -152,7 +152,7 @@ library
       src
   ghc-options: -Wall -O2 -threaded
   build-depends:
-      Cabal
+      Cabal <3.12
     , async >=2.2.5
     , base >=4.7 && <5
     , bytestring
@@ -187,7 +187,7 @@ library hindent-internal
       internal
   ghc-options: -Wall -O2 -threaded
   build-depends:
-      Cabal
+      Cabal <3.12
     , async >=2.2.5
     , base >=4.7 && <5
     , bytestring
@@ -222,7 +222,7 @@ executable hindent
       app
   ghc-options: -Wall -O2 -threaded
   build-depends:
-      Cabal
+      Cabal <3.12
     , async >=2.2.5
     , base >=4.7 && <5
     , bytestring
@@ -258,7 +258,7 @@ test-suite hindent-test
       tests
   ghc-options: -Wall -O2 -threaded
   build-depends:
-      Cabal
+      Cabal <3.12
     , Diff
     , async >=2.2.5
     , base >=4.7 && <5
@@ -297,7 +297,7 @@ benchmark hindent-bench
       benchmarks
   ghc-options: -Wall -O2 -threaded
   build-depends:
-      Cabal
+      Cabal <3.12
     , async >=2.2.5
     , base >=4.7 && <5
     , bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ github:       mihaimaruseac/hindent
 ghc-options: -Wall -O2 -threaded
 
 dependencies:
-  - Cabal
+  - Cabal < 3.12
   - async >= 2.2.5
   - base >= 4.7 && < 5
   - bytestring


### PR DESCRIPTION
### Description of the PR

To fix a build error.

Cabal 3.12 uses `SymbolicPathX`, but it is not exported from the library, and thus, we cannot use it.

Probably we should set version bounds to all dependencies, and update the bounds when needed, e.g., new functions are required, to keep up with the new Stackage LTS, etc.

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
