### PR TITLE
fix: prevent unwanted `$` prepending to Template Haskell functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Template Haskell functions no longer get unwanted '$' symbols prepended ([#1033])
+
 ### Removed
 
 ## [6.2.1] - 2024-11-28
@@ -402,6 +404,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#1033]: https://github.com/mihaimaruseac/hindent/pull/1033
 [#1000]: https://github.com/mihaimaruseac/hindent/pull/1000
 [#967]: https://github.com/mihaimaruseac/hindent/pull/967
 [#950]: https://github.com/mihaimaruseac/hindent/pull/950

--- a/TESTS.md
+++ b/TESTS.md
@@ -3132,6 +3132,17 @@ Typed splice
 foo = $$bar
 ```
 
+Template Haskell function calls without arguments should not get '$' prepended
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/973
+{-# LANGUAGE TemplateHaskell #-}
+
+makeSem ''MyData
+
+deriveJSON
+```
+
 ## Comments
 
 Only comments

--- a/hindent.cabal
+++ b/hindent.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
### Description of the PR

Fixes: #973

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
