### PR TITLE
`hindent-mode` Various small changes

### DIFF
--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -1,10 +1,10 @@
-;;; hindent.el --- Indent haskell code using the "hindent" program
+;;; hindent.el --- Indent haskell code using the "hindent" program -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2014 Chris Done. All rights reserved.
 
 ;; Author: Chris Done <chrisdone@gmail.com>
 ;; URL: https://github.com/chrisdone/hindent
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((emacs "27.1"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@
 
 ;;; Code:
 
-(require 'cl-lib)
+(eval-when-compile (require 'cl-lib))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Customization properties
@@ -67,7 +67,8 @@ For hindent versions lower than 5, you must set this to a non-nil string."
   :safe #'listp)
 
 (defcustom hindent-reformat-buffer-on-save nil
-  "Set to t to run `hindent-reformat-buffer' when a buffer in `hindent-mode' is saved."
+  "Set to t to run `hindent-reformat-buffer' when a buffer in
+`hindent-mode' is saved."
   :group 'hindent
   :type 'boolean
   :safe #'booleanp)
@@ -207,14 +208,7 @@ the file."
                                 (buffer-string))))
                 (if (not (string= new-str orig-str))
                     (progn
-                      (if (fboundp 'replace-region-contents)
-                          (replace-region-contents
-                           beg end (lambda () temp))
-                        (let ((line (line-number-at-pos))
-                              (col (current-column)))
-                          (delete-region beg
-                                         end)
-                          (insert new-str)))
+                      (replace-region-contents beg end (lambda () temp))
                       (message "Formatted."))
                   (message "Already formatted."))))
              (t
@@ -254,35 +248,33 @@ work."
    (t
     (save-excursion
       (let ((start
-             (or (cl-letf
-                     (((symbol-function 'jump)
-                       #'(lambda ()
-                           (search-backward-regexp "^[^ \n]" nil t 1)
-                           (cond
-                            ((save-excursion (goto-char (line-beginning-position))
-                                             (looking-at "|]"))
-                             (jump))
-                            (t (unless (or (looking-at "^-}$")
-                                           (looking-at "^{-$"))
-                                 (point)))))))
+             (or (cl-labels
+                     ((jump ()
+                        (search-backward-regexp "^[^ \n]" nil t 1)
+                        (cond
+                         ((save-excursion (goto-char (line-beginning-position))
+                                          (looking-at "|]"))
+                          (jump))
+                         (t (unless (or (looking-at "^-}$")
+                                        (looking-at "^{-$"))
+                              (point))))))
                    (goto-char (line-end-position))
                    (jump))
                  0))
             (end
              (progn
                (goto-char (1+ (point)))
-               (or (cl-letf
-                       (((symbol-function 'jump)
-                         #'(lambda ()
-                             (when (search-forward-regexp "[\n]+[^ \n]" nil t 1)
-                               (cond
-                                ((save-excursion (goto-char (line-beginning-position))
-                                                 (looking-at "|]"))
-                                 (jump))
-                                (t (forward-char -1)
-                                   (search-backward-regexp "[^\n ]" nil t)
-                                   (forward-char)
-                                   (point)))))))
+               (or (cl-labels
+                       ((jump ()
+                          (when (search-forward-regexp "[\n]+[^ \n]" nil t 1)
+                            (cond
+                             ((save-excursion (goto-char (line-beginning-position))
+                                              (looking-at "|]"))
+                              (jump))
+                             (t (forward-char -1)
+                                (search-backward-regexp "[^\n ]" nil t)
+                                (forward-char)
+                                (point))))))
                      (jump))
                    (point-max)))))
         (cons start end))))))

--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -3,7 +3,7 @@
 ;; Copyright (c) 2014 Chris Done. All rights reserved.
 
 ;; Author: Chris Done <chrisdone@gmail.com>
-;; URL: https://github.com/chrisdone/hindent
+;; URL: https://github.com/mihaimaruseac/hindent
 ;; Package-Requires: ((emacs "27.1"))
 
 ;; This file is free software; you can redistribute it and/or modify

--- a/elisp/hindent.el
+++ b/elisp/hindent.el
@@ -63,8 +63,9 @@ For hindent versions lower than 5, you must set this to a non-nil string."
 (defcustom hindent-extra-args nil
   "Extra arguments to give to hindent"
   :group 'hindent
-  :type 'sexp
-  :safe #'listp)
+  :type '(choice
+          (repeat string)
+          (function :tag "Function with no arguments returning a list of strings")))
 
 (defcustom hindent-reformat-buffer-on-save nil
   "Set to t to run `hindent-reformat-buffer' when a buffer in
@@ -301,7 +302,9 @@ work."
    (when hindent-style
      (list "--style" hindent-style))
    (when hindent-extra-args
-     hindent-extra-args)))
+     (if (functionp hindent-extra-args)
+         (funcall hindent-extra-args)
+       hindent-extra-args))))
 
 (provide 'hindent)
 


### PR DESCRIPTION
### Description of the PR

Hi,

first of all: I realise that this is a big of a grab-bag, and perhaps I should have opened several PRs, but the individual changes are so small that I would feel a bit uneasy with that. Basically, these are small changes to `hindent-mode` that update the code to slightly more modern standards.

### Commit Summary

#### Show error on exit code ≠ 0

Instead of checking for just (= ret 1), we should really show an error whenever the exit code is not clean (i.e., 0). This prevents hindent-mode from silently failing, which gives the indication of a command not doing anything at all.

#### Fix bytecompile warnings

+ Enable lexical binding.
+ Replace cl-letf with cl-labels.
+ Depend on Emacs 27.1 for replace-region-contents, which is old enough at this point to have trickled down to even Debian stable.
+ Only require cl-lib at compile time.

#### hindent-extra-args: Allow type to be a function

This is useful for backends (e.g., fourmolu) that allow looking for a cabal file in some kind of directory. For example, utilising project.el, one could write something like

``` emacs-lisp
(setq hindent-process-path "fourmolu")
(setq hindent-extra-args
      (lambda ()
        `("--stdin-input-file" (project-root (project-current)))))
```

#### hindent.el: Update URL

### Checklist

- [ ] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.

  Should I do this? Or is this rather reserved for `hindent` itself?

- [n/a] Add tests in [TESTS.md](/TESTS.md) if possible.
