### PR TITLE
fix: add an indent after an operator when `line-breaks` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Correctly indent type family right-hand sides broken at operators configured with the `line-breaks` option ([#1252])
 - Preserve parentheses around infix function left-hand sides with extra arguments ([#1243])
 - Recognize and normalize CPP directives with spaces after `#` ([#1249])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Preserve parentheses around infix function left-hand sides with extra arguments ([#1243])
 - Recognize and normalize CPP directives with spaces after `#`, including multiline directives ([#1249])
+- Correctly indent type family right-hand sides broken at operators configured with the `line-breaks` option ([#1252])
 
 ### Removed
 
@@ -431,6 +432,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#1252]: https://github.com/mihaimaruseac/hindent/pull/1252
 [#1249]: https://github.com/mihaimaruseac/hindent/pull/1249
 [#1243]: https://github.com/mihaimaruseac/hindent/pull/1243
 [#1163]: https://github.com/mihaimaruseac/hindent/pull/1163

--- a/TESTS.md
+++ b/TESTS.md
@@ -1740,6 +1740,15 @@ type family Closed (a :: k) :: Bool where
   Closed x = 'True
 ```
 
+Indent line breaks in type family right-hand sides
+
+```haskell line-breaks :>
+-- https://github.com/mihaimaruseac/hindent/issues/490
+type family F a where
+  F a = a
+        :> a
+```
+
 ### Type family instance declarations
 
 Without holes

--- a/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
+++ b/src/HIndent/Ast/Declaration/Family/Type/Equation.hs
@@ -21,7 +21,7 @@ data TypeEquation = TypeEquation
   }
 
 instance Pretty TypeEquation where
-  pretty TypeEquation {..} = spaced [lhs, string "=", pretty bind]
+  pretty TypeEquation {..} = spaced [lhs, string "="] >> space |=> pretty bind
     where
       lhs = spaced $ [pretty name] <> [pretty types | hasTypeArguments types]
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -13,6 +13,7 @@ import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified Data.ByteString.Lazy.UTF8 as LUTF8
 import qualified Data.ByteString.UTF8 as UTF8
 import Data.Function
+import qualified Data.Text as T
 import Data.Version
 import qualified HIndent
 import HIndent (Config(..))
@@ -55,6 +56,13 @@ toSpec = go
           it (UTF8.toString desc)
             $ shouldBeReadable (reformat cfg' code) (L.fromStrict code)
           go next
+        s
+          | "haskell":"line-breaks":operators <- words $ UTF8.toString s
+          , not $ null operators -> do
+            let cfg' = cfg {configLineBreaks = T.pack <$> operators}
+            it (UTF8.toString desc)
+              $ shouldBeReadable (reformat cfg' code) (L.fromStrict code)
+            go next
         "haskell given" ->
           case skipEmptyLines next of
             CodeFence "haskell expect" codeExpect:next' -> do


### PR DESCRIPTION
### Description of the PR

Fixes: #490 

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
