### PR TITLE
fix: locate `INLINE` pragmas immediately after a declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Preserve parentheses around infix function left-hand sides with extra arguments ([#1243])
 - Recognize and normalize CPP directives with spaces after `#`, including multiline directives ([#1249])
 - Correctly indent type family right-hand sides broken at operators configured with the `line-breaks` option ([#1252])
+- Keep `INLINE` pragmas immediately after their associated declarations ([#1257])
 
 ### Removed
 
@@ -432,6 +433,7 @@ This version is accidentally pushlished, and is the same as 5.3.3.
 [@uhbif19]: https://github.com/uhbif19
 [@toku-sa-n]: https://github.com/toku-sa-n
 
+[#1257]: https://github.com/mihaimaruseac/hindent/pull/1257
 [#1252]: https://github.com/mihaimaruseac/hindent/pull/1252
 [#1249]: https://github.com/mihaimaruseac/hindent/pull/1249
 [#1243]: https://github.com/mihaimaruseac/hindent/pull/1243

--- a/TESTS.md
+++ b/TESTS.md
@@ -1572,6 +1572,14 @@ pattern x :| xs <- x : xs
 
 ### Pragma declarations
 
+An `INLINE` pragma immediately after its value definition
+
+```haskell
+-- https://github.com/mihaimaruseac/hindent/issues/483
+x = ()
+{-# INLINE x #-}
+```
+
 `INLINE`
 
 ```haskell

--- a/src/HIndent/Ast/Declaration.hs
+++ b/src/HIndent/Ast/Declaration.hs
@@ -4,6 +4,7 @@ module HIndent.Ast.Declaration
   ( Declaration(..)
   , mkDeclaration
   , isSignature
+  , isInlinePragma
   ) where
 
 import Control.Applicative
@@ -106,3 +107,7 @@ isSignature :: Declaration -> Bool
 isSignature Signature {} = True
 isSignature StandaloneKindSignature {} = True
 isSignature _ = False
+
+isInlinePragma :: Declaration -> Bool
+isInlinePragma (Signature signature) = isInline signature
+isInlinePragma _ = False

--- a/src/HIndent/Ast/Declaration/Collection.hs
+++ b/src/HIndent/Ast/Declaration/Collection.hs
@@ -25,10 +25,12 @@ instance Pretty DeclarationCollection where
     where
       addDeclSeparator [] = []
       addDeclSeparator [x] = [(x, Nothing)]
-      addDeclSeparator (x:xs) =
-        (x, Just $ declSeparator $ getNode x) : addDeclSeparator xs
-      declSeparator (isSignature -> True) = newline
-      declSeparator _ = blankline
+      addDeclSeparator (x:y:xs) =
+        (x, Just $ declSeparator (getNode x) (getNode y))
+          : addDeclSeparator (y : xs)
+      declSeparator (isSignature -> True) _ = newline
+      declSeparator _ (isInlinePragma -> True) = newline
+      declSeparator _ _ = blankline
 
 mkDeclarationCollection :: GHC.HsModule' -> DeclarationCollection
 mkDeclarationCollection GHC.HsModule {..} =

--- a/src/HIndent/Ast/Declaration/Signature.hs
+++ b/src/HIndent/Ast/Declaration/Signature.hs
@@ -6,6 +6,7 @@
 module HIndent.Ast.Declaration.Signature
   ( Signature
   , mkSignature
+  , isInline
   ) where
 
 import qualified GHC.Types.Basic as GHC
@@ -225,3 +226,6 @@ mkSignature (GHC.MinimalSig _ _ xs) =
 mkSignature GHC.IdSig {} =
   error "`ghc-lib-parser` never generates this AST node."
 #endif
+isInline :: Signature -> Bool
+isInline Inline {} = True
+isInline _ = False


### PR DESCRIPTION
### Description of the PR

Fixes: #483 

### Checklist

- [x] Add a changelog if necessary. See https://keepachangelog.com/ for how to write it.
- [x] Add tests in [TESTS.md](/TESTS.md) if possible.
